### PR TITLE
Update canary runtime version to 6.2

### DIFF
--- a/scripts/eks/appsignals/create-canaries.sh
+++ b/scripts/eks/appsignals/create-canaries.sh
@@ -143,7 +143,7 @@ create_canary() {
         --artifact-s3-location "s3://$ARTIFACT_BUCKET" \
         --code Handler="$canary_name.handler",S3Bucket="$CODE_BUCKET",S3Key="$canary_name" \
         --execution-role-arn $canary_execution_role_arn \
-        --runtime-version "syn-nodejs-puppeteer-4.0" \
+        --runtime-version "syn-nodejs-puppeteer-6.2" \
         --schedule Expression="rate(1 minute)" \
         --run-config ActiveTracing=true,EnvironmentVariables={URL=$ENDPOINT} \
         --region $REGION \


### PR DESCRIPTION
*Issue*
The creation of canaries will soon fail due to the new Lambda release.

*Description of changes:*
Create canaries with runtime version v6.2.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

