### PR TITLE
Retrieve E2E testing resources from application framework repo

### DIFF
--- a/.github/workflows/appsignals-e2e-eks-test.yml
+++ b/.github/workflows/appsignals-e2e-eks-test.yml
@@ -49,7 +49,7 @@ jobs:
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          role-to-assume: ${{ secrets.E2E_TEST_ROLE_ARN }}
+          role-to-assume: arn:aws:iam::${{ env.TEST_ACCOUNT }}:role/${{ secrets.APP_SIGNALS_E2E_TEST_ROLE_NAME }}
           aws-region: ${{ env.AWS_DEFAULT_REGION }}
 
       # local directory to store the kubernetes config

--- a/.github/workflows/appsignals-e2e-eks-test.yml
+++ b/.github/workflows/appsignals-e2e-eks-test.yml
@@ -36,10 +36,10 @@ jobs:
 
       # This step avoids code duplication for terraform templates and the validator
       # To simplify, we get the entire repo and put it into a separate folder
-      - name: Get testing resources from ADOT
+      - name: Get testing resources from aws-application-signals-test-framework
         uses: actions/checkout@v4
         with:
-          repository: aws-observability/aws-otel-java-instrumentation
+          repository: aws-observability/aws-application-signals-test-framework
           ref: main
           path: ${{ env.TEST_RESOURCES_FOLDER }}
 
@@ -87,7 +87,7 @@ jobs:
           terraform_wrapper: false
 
       - name: Deploy sample app via terraform
-        working-directory: ${{ env.TEST_RESOURCES_FOLDER }}/testing/terraform/eks
+        working-directory: ${{ env.TEST_RESOURCES_FOLDER }}/terraform/eks
         run: |
           terraform init
           terraform validate
@@ -137,7 +137,7 @@ jobs:
       - name: Get the sample app endpoint
         run: |
           echo "APP_ENDPOINT=$(terraform output sample_app_endpoint)" >> $GITHUB_ENV
-        working-directory: ${{ env.TEST_RESOURCES_FOLDER }}/testing/terraform/eks
+        working-directory: ${{ env.TEST_RESOURCES_FOLDER }}/terraform/eks
 
       - name: Wait for app endpoint to come online
         id: endpoint-check
@@ -164,12 +164,16 @@ jobs:
           curl -S -s -o /dev/null http://${{ env.APP_ENDPOINT }}/remote-service?ip=${{ env.REMOTE_SERVICE_IP }}/
           curl -S -s -o /dev/null http://${{ env.APP_ENDPOINT }}/client-call/
 
+      - name: Build Gradle
+        working-directory: ${{ env.TEST_RESOURCES_FOLDER }}
+        run: ./gradlew
+
       # Validation for app signals telemetry data
       - name: Validate generated EMF logs
         id: log-validation
         if: steps.endpoint-check.outcome == 'success' && !cancelled()
         working-directory: ${{ env.TEST_RESOURCES_FOLDER }}
-        run: ./gradlew testing:validator:run --args='-c eks/log-validation.yml
+        run: ./gradlew validator:run --args='-c eks/log-validation.yml
           --testing-id ${{ env.TESTING_ID }}
           --endpoint http://${{ env.APP_ENDPOINT }}
           --region ${{ env.AWS_DEFAULT_REGION }}
@@ -187,7 +191,7 @@ jobs:
         id: metric-validation
         if: (success() || steps.log-validation.outcome == 'failure') && !cancelled()
         working-directory: ${{ env.TEST_RESOURCES_FOLDER }}
-        run: ./gradlew testing:validator:run --args='-c eks/metric-validation.yml
+        run: ./gradlew validator:run --args='-c eks/metric-validation.yml
           --testing-id ${{ env.TESTING_ID }}
           --endpoint http://${{ env.APP_ENDPOINT }}
           --region ${{ env.AWS_DEFAULT_REGION }}
@@ -206,7 +210,7 @@ jobs:
         id: trace-validation
         if: (success() || steps.log-validation.outcome == 'failure' || steps.metric-validation.outcome == 'failure') && !cancelled()
         working-directory: ${{ env.TEST_RESOURCES_FOLDER }}
-        run: ./gradlew testing:validator:run --args='-c eks/trace-validation.yml
+        run: ./gradlew validator:run --args='-c eks/trace-validation.yml
           --testing-id ${{ env.TESTING_ID }}
           --endpoint http://${{ env.APP_ENDPOINT }}
           --region ${{ env.AWS_DEFAULT_REGION }}
@@ -249,7 +253,7 @@ jobs:
       - name: Terraform destroy
         if: always()
         continue-on-error: true
-        working-directory: ${{ env.TEST_RESOURCES_FOLDER }}/testing/terraform/eks
+        working-directory: ${{ env.TEST_RESOURCES_FOLDER }}/terraform/eks
         run: |
           terraform destroy -auto-approve \
             -var="test_id=${{ env.TESTING_ID }}" \


### PR DESCRIPTION
*Issue #, if available:*
Testing resources for E2E Testing has been moved to https://github.com/aws-observability/aws-application-signals-test-framework, need to update e2e testing workflow to retrieve from that repo. 

Test Run: https://github.com/aws-observability/application-signals-demo/actions/runs/8100756207

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

