### PR TITLE
Update enable-app-signal script to use the latest addon

### DIFF
--- a/scripts/eks/appsignals/enable-app-signals.sh
+++ b/scripts/eks/appsignals/enable-app-signals.sh
@@ -59,7 +59,6 @@ if [[ "${result}" == *"No addon: "* ]];  then
     aws eks create-addon \
         --cluster-name ${CLUSTER_NAME} \
         --addon-name amazon-cloudwatch-observability \
-        --addon-version v1.2.0-eksbuild.1 \
         --region ${REGION}
     # wait until the amazon-cloudwatch-observability add-on is active    
     # Fetch the initial status


### PR DESCRIPTION
*Issue #, if available:*
The EKS add-on on the enable-app-signals.sh script is still using the old v1.2.0 version

*Description of changes:*
Removed argument in the script that specifies the version, thereby using the latest one. 

Test run: https://github.com/aws-observability/application-signals-demo/actions/runs/8176925726/job/22357422956#step:13:50

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

