### PR TITLE
Updated cleanup script to avoid deadlock when deleting persistent volume.

### DIFF
--- a/scripts/eks/appsignals/deploy-sample-app.sh
+++ b/scripts/eks/appsignals/deploy-sample-app.sh
@@ -46,6 +46,8 @@ ACCOUNT=$(aws sts get-caller-identity | jq -r '.Account')
 kubectl ${OPERATION} --namespace=$NAMESPACE -f ./sample-app/db/
 host=db.$NAMESPACE.svc.cluster.local
 
+sleep 60
+
 for config in $(ls ./sample-app/*.yaml)
 do
     sed -e "s/111122223333.dkr.ecr.us-west-2/$ACCOUNT.dkr.ecr.$REGION/g" -e 's#\${REGION}'"#${REGION}#g" -e 's#\${DB_SERVICE_HOST}'"#${host}#g" $config | kubectl ${OPERATION} --namespace=$NAMESPACE -f -

--- a/scripts/eks/appsignals/one-step/cleanup.sh
+++ b/scripts/eks/appsignals/one-step/cleanup.sh
@@ -46,10 +46,6 @@ echo "Deleting canaries"
 ../create-canaries.sh $REGION delete
 check_if_step_failed_and_exit "There was an error deleting the canaries. Please make sure they are deleted properly before proceeding with the following steps"
 
-# force delete db service and pvc as this might cause the cluster delete to hang
-kubectl delete pods -l io.kompose.service=db
-kubectl delete pvc data  --grace-period=0 --force 
-
 ../deploy-sample-app.sh $CLUSTER_NAME $REGION $NAMESPACE delete
 check_if_step_failed_and_exit "There was an error deleting the sample apps. Please make sure they are deleted properly before proceeding with the following steps"
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Updated cleanup script to avoid deadlock when deleting persistent volume.
- Tested the script multiple times and verified that it works as expected.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

