### PR TITLE
Update Log Group to /aws/application-signals/data

### DIFF
--- a/scripts/eks/appsignals/clean-app-signals.sh
+++ b/scripts/eks/appsignals/clean-app-signals.sh
@@ -22,4 +22,4 @@ aws eks delete-addon --cluster-name $CLUSTER_NAME --addon-name amazon-cloudwatch
 echo "Deleting ServiceAccount"
 eksctl delete iamserviceaccount --cluster $CLUSTER_NAME --region $REGION --name cloudwatch-agent --namespace amazon-cloudwatch
 
-aws logs delete-log-group --log-group-name '/aws/appsignals/eks' --region $REGION
+aws logs delete-log-group --log-group-name '/aws/application-signals/data' --region $REGION


### PR DESCRIPTION
*Issue #, if available:*
The log group used to store EMF logs has been changed to `/aws/application-signals/data`. Currently the clean-app-signals.sh script is failing due to this mismatch. 

*Description of changes:*
Update the log group deletion command

Test:
Ran latest `enable-app-signals.sh` in EKS cluster, generated telemetry, then ran `clean-app-signal.sh`. No errors during the process

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

