### PR TITLE
Bedrock genai demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ This code for sample application is intended for demonstration purposes only. It
 * eksctl is installed - https://docs.aws.amazon.com/eks/latest/userguide/eksctl.html
 * jq is installed - https://jqlang.github.io/jq/download/
 * [Optional] If you plan to install the infrastructure resources using Terraform, terraform cli is required. https://developer.hashicorp.com/terraform/tutorials/aws-get-started/install-cli
-
+* [Optional] If you want to try out AWS Bedrock/GenAI support with Application Signals, enable Amazon Titian, Anthropic Claude, Meta Llama foundation models by following the instructions in https://docs.aws.amazon.com/bedrock/latest/userguide/model-access.html
 # EKS demo
 
 ## Deploy via Shell Scripts

--- a/scripts/ec2/appsignals/setup-ec2-demo.sh
+++ b/scripts/ec2/appsignals/setup-ec2-demo.sh
@@ -71,6 +71,7 @@ function create_resources() {
     aws iam attach-role-policy --role-name $IAM_ROLE_NAME --policy-arn "arn:aws:iam::aws:policy/AmazonRDSFullAccess"
     aws iam attach-role-policy --role-name $IAM_ROLE_NAME --policy-arn "arn:aws:iam::aws:policy/CloudWatchAgentServerPolicy"
     aws iam attach-role-policy --role-name $IAM_ROLE_NAME --policy-arn "arn:aws:iam::aws:policy/AWSXrayWriteOnlyAccess"
+    aws iam attach-role-policy --role-name $IAM_ROLE_NAME --policy-arn "arn:aws:iam::aws:policy/AmazonBedrockFullAccess"
 
     # Create instance profile
     aws iam create-instance-profile --instance-profile-name $INSTANCE_PROFILE
@@ -603,7 +604,7 @@ function delete_resources() {
 
 
     # Detach and delete IAM policies and role
-    policy_arns=("arn:aws:iam::aws:policy/AmazonDynamoDBFullAccess" "arn:aws:iam::aws:policy/AmazonKinesisFullAccess" "arn:aws:iam::aws:policy/AmazonS3FullAccess" "arn:aws:iam::aws:policy/AmazonSQSFullAccess" "arn:aws:iam::aws:policy/AmazonRDSFullAccess" "arn:aws:iam::aws:policy/CloudWatchAgentServerPolicy" "arn:aws:iam::aws:policy/AWSXrayWriteOnlyAccess")
+    policy_arns=("arn:aws:iam::aws:policy/AmazonDynamoDBFullAccess" "arn:aws:iam::aws:policy/AmazonBedrockFullAccess" "arn:aws:iam::aws:policy/AmazonKinesisFullAccess" "arn:aws:iam::aws:policy/AmazonS3FullAccess" "arn:aws:iam::aws:policy/AmazonSQSFullAccess" "arn:aws:iam::aws:policy/AmazonRDSFullAccess" "arn:aws:iam::aws:policy/CloudWatchAgentServerPolicy" "arn:aws:iam::aws:policy/AWSXrayWriteOnlyAccess")
     for arn in "${policy_arns[@]}"
     do
       echo $arn

--- a/scripts/eks/appsignals/deploy-sample-app.sh
+++ b/scripts/eks/appsignals/deploy-sample-app.sh
@@ -30,6 +30,7 @@ if [[ $OPERATION == "apply" ]]; then
         --attach-policy-arn arn:aws:iam::aws:policy/AmazonS3FullAccess \
         --attach-policy-arn arn:aws:iam::aws:policy/AmazonKinesisFullAccess \
         --attach-policy-arn arn:aws:iam::aws:policy/AmazonDynamoDBFullAccess \
+        --attach-policy-arn arn:aws:iam::aws:policy/AmazonBedrockFullAccess \
         --approve \
         --override-existing-serviceaccounts
 else

--- a/scripts/k8s/appsignals/setup-k8s-demo.sh
+++ b/scripts/k8s/appsignals/setup-k8s-demo.sh
@@ -65,6 +65,7 @@ function create_resources() {
     # Create an IAM role and attach policies
     aws iam create-role --role-name $IAM_ROLE_NAME --assume-role-policy-document file://trust-policy.json
     aws iam attach-role-policy --role-name $IAM_ROLE_NAME --policy-arn "arn:aws:iam::aws:policy/AmazonDynamoDBFullAccess"
+    aws iam attach-role-policy --role-name $IAM_ROLE_NAME --policy-arn "arn:aws:iam::aws:policy/AmazonBedrockFullAccess"
     aws iam attach-role-policy --role-name $IAM_ROLE_NAME --policy-arn "arn:aws:iam::aws:policy/AmazonKinesisFullAccess"
     aws iam attach-role-policy --role-name $IAM_ROLE_NAME --policy-arn "arn:aws:iam::aws:policy/AmazonS3FullAccess"
     aws iam attach-role-policy --role-name $IAM_ROLE_NAME --policy-arn "arn:aws:iam::aws:policy/AmazonSQSFullAccess"
@@ -296,7 +297,7 @@ function delete_resources() {
 
 
     # Detach and delete IAM policies and role
-    policy_arns=("arn:aws:iam::aws:policy/AmazonDynamoDBFullAccess" "arn:aws:iam::aws:policy/AmazonKinesisFullAccess" "arn:aws:iam::aws:policy/AmazonS3FullAccess" "arn:aws:iam::aws:policy/AmazonSQSFullAccess" "arn:aws:iam::aws:policy/AmazonRDSFullAccess" "arn:aws:iam::aws:policy/CloudWatchAgentServerPolicy" "arn:aws:iam::aws:policy/AWSXrayWriteOnlyAccess" "arn:aws:iam::aws:policy/service-role/AmazonEBSCSIDriverPolicy" "arn:aws:iam::aws:policy/AmazonEC2FullAccess")
+    policy_arns=("arn:aws:iam::aws:policy/AmazonDynamoDBFullAccess" "arn:aws:iam::aws:policy/AmazonBedrockFullAccess" "arn:aws:iam::aws:policy/AmazonKinesisFullAccess" "arn:aws:iam::aws:policy/AmazonS3FullAccess" "arn:aws:iam::aws:policy/AmazonSQSFullAccess" "arn:aws:iam::aws:policy/AmazonRDSFullAccess" "arn:aws:iam::aws:policy/CloudWatchAgentServerPolicy" "arn:aws:iam::aws:policy/AWSXrayWriteOnlyAccess" "arn:aws:iam::aws:policy/service-role/AmazonEBSCSIDriverPolicy" "arn:aws:iam::aws:policy/AmazonEC2FullAccess")
 
     for arn in "${policy_arns[@]}"
     do

--- a/spring-petclinic-api-gateway/src/main/java/org/springframework/samples/petclinic/api/application/CustomersServiceClient.java
+++ b/spring-petclinic-api-gateway/src/main/java/org/springframework/samples/petclinic/api/application/CustomersServiceClient.java
@@ -86,6 +86,14 @@ public class CustomersServiceClient {
     }
 
     @WithSpan
+    public Mono<Void> diagnosePet(final int ownerId, final int petId) {
+        log.info("DEBUG: Inside the diagnose API");
+        return webClientBuilder.build().get()
+                .uri("http://customers-service/diagnose/owners/{ownerId}/pets/{petId}", ownerId, petId)
+                .retrieve()
+                .bodyToMono(Void.class);
+    }
+    @WithSpan
     public Mono<Void> updatePet(final int ownerId, final int petId, final PetRequest petRequest) {
         return webClientBuilder.build().put()
             .uri("http://customers-service/owners/{ownerId}/pets/{petId}", ownerId, petId)

--- a/spring-petclinic-api-gateway/src/main/java/org/springframework/samples/petclinic/api/application/CustomersServiceClient.java
+++ b/spring-petclinic-api-gateway/src/main/java/org/springframework/samples/petclinic/api/application/CustomersServiceClient.java
@@ -18,6 +18,7 @@
  */
 package org.springframework.samples.petclinic.api.application;
 
+import lombok.extern.slf4j.Slf4j;
 import io.opentelemetry.instrumentation.annotations.SpanAttribute;
 import io.opentelemetry.instrumentation.annotations.WithSpan;
 import lombok.RequiredArgsConstructor;
@@ -35,6 +36,7 @@ import org.springframework.web.server.ResponseStatusException;
  * @author Maciej Szarlinski
  */
 @Component
+@Slf4j
 @RequiredArgsConstructor
 public class CustomersServiceClient {
 

--- a/spring-petclinic-api-gateway/src/main/java/org/springframework/samples/petclinic/api/boundary/web/ApiController.java
+++ b/spring-petclinic-api-gateway/src/main/java/org/springframework/samples/petclinic/api/boundary/web/ApiController.java
@@ -3,6 +3,7 @@
 package org.springframework.samples.petclinic.api.boundary.web;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.samples.petclinic.api.application.*;
 import org.springframework.samples.petclinic.api.dto.*;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -17,6 +18,7 @@ import reactor.core.publisher.Mono;
 
 @RestController
 @RequiredArgsConstructor
+@Slf4j
 @RequestMapping("/api/")
 public class ApiController {
 

--- a/spring-petclinic-api-gateway/src/main/java/org/springframework/samples/petclinic/api/boundary/web/ApiController.java
+++ b/spring-petclinic-api-gateway/src/main/java/org/springframework/samples/petclinic/api/boundary/web/ApiController.java
@@ -56,6 +56,11 @@ public class ApiController {
         return customersServiceClient.getPet(ownerId, petId);
     }
 
+    @GetMapping(value = "customer/diagnose/owners/{ownerId}/pets/{petId}")
+    public Mono<Void> diagnosePet(final @PathVariable int ownerId, final @PathVariable int petId) {
+        log.info("DEBUG: Inside the diagnose API - diagnosePet");
+        return customersServiceClient.diagnosePet(ownerId, petId);
+    }
     @PutMapping("customer/owners/{ownerId}/pets/{petId}")
     public Mono<Void> updatePet(final @PathVariable int ownerId, final @PathVariable int petId, @RequestBody PetRequest petRequest) {
         return customersServiceClient.updatePet(ownerId, petId, petRequest);

--- a/spring-petclinic-customers-service/pom.xml
+++ b/spring-petclinic-customers-service/pom.xml
@@ -1,157 +1,214 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-<modelVersion>4.0.0</modelVersion>
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
 
-<groupId>org.springframework.samples.petclinic.client</groupId>
-<artifactId>spring-petclinic-customers-service</artifactId>
-<packaging>jar</packaging>
-<description>Spring PetClinic Customers Service</description>
+  <groupId>org.springframework.samples.petclinic.client</groupId>
+  <artifactId>spring-petclinic-customers-service</artifactId>
+  <packaging>jar</packaging>
+  <description>Spring PetClinic Customers Service</description>
 
-<parent>
-  <groupId>org.springframework.samples</groupId>
-  <artifactId>spring-petclinic-microservices</artifactId>
-  <version>2.6.7</version>
-</parent>
+  <parent>
+    <groupId>org.springframework.samples</groupId>
+    <artifactId>spring-petclinic-microservices</artifactId>
+    <version>2.6.7</version>
+  </parent>
 
-<properties>
-  <docker.image.exposed.port>8081</docker.image.exposed.port>
-  <docker.image.dockerfile.dir>${basedir}/../docker</docker.image.dockerfile.dir>
-</properties>
+  <properties>
+    <docker.image.exposed.port>8081</docker.image.exposed.port>
+    <docker.image.dockerfile.dir>${basedir}/../docker</docker.image.dockerfile.dir>
+  </properties>
 
-<dependencies>
+  <dependencies>
 
-  <!-- Spring Boot -->
-  <dependency>
-    <groupId>org.springframework.boot</groupId>
-    <artifactId>spring-boot-starter-actuator</artifactId>
-  </dependency>
-  <dependency>
-    <groupId>org.springframework.boot</groupId>
-    <artifactId>spring-boot-starter-data-jpa</artifactId>
-  </dependency>
-  <dependency>
-    <groupId>org.springframework.boot</groupId>
-    <artifactId>spring-boot-starter-test</artifactId>
-    <scope>test</scope>
-  </dependency>
-  <dependency>
-    <groupId>org.springframework.boot</groupId>
-    <artifactId>spring-boot-starter-web</artifactId>
-    <version>2.5.12</version>
-  </dependency>
+    <!-- Spring Boot -->
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-actuator</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-data-jpa</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-test</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-web</artifactId>
+      <version>2.5.12</version>
+    </dependency>
 
-  <!-- Spring Cloud -->
-  <dependency>
-    <groupId>org.springframework.cloud</groupId>
-    <artifactId>spring-cloud-starter-config</artifactId>
-  </dependency>
-  <dependency>
-    <groupId>org.springframework.cloud</groupId>
-    <artifactId>spring-cloud-starter-netflix-eureka-client</artifactId>
-  </dependency>
+    <!-- Spring Cloud -->
+    <dependency>
+      <groupId>org.springframework.cloud</groupId>
+      <artifactId>spring-cloud-starter-config</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.cloud</groupId>
+      <artifactId>spring-cloud-starter-netflix-eureka-client</artifactId>
+    </dependency>
 
-  <!-- Third parties -->
-  <dependency>
-    <groupId>mysql</groupId>
-    <artifactId>mysql-connector-java</artifactId>
-    <scope>runtime</scope>
-    <version>8.0.28</version>
-  </dependency>
-  <dependency>
-    <groupId>org.hsqldb</groupId>
-    <artifactId>hsqldb</artifactId>
-    <scope>runtime</scope>
-    <version>2.7.1</version>
-  </dependency>
-  <dependency>
-    <groupId>org.jolokia</groupId>
-    <artifactId>jolokia-core</artifactId>
-  </dependency>
-  <dependency>
-    <groupId>org.projectlombok</groupId>
-    <artifactId>lombok</artifactId>
-    <scope>provided</scope>
-  </dependency>
-  <dependency>
-    <groupId>io.micrometer</groupId>
-    <artifactId>micrometer-registry-prometheus</artifactId>
-  </dependency>
-  <dependency>
-    <groupId>de.codecentric</groupId>
-    <artifactId>chaos-monkey-spring-boot</artifactId>
-  </dependency>
-  <dependency>
-    <groupId>software.amazon.awssdk</groupId>
-    <artifactId>sts</artifactId>
-    <version>2.20.46</version>
-  </dependency>
-  <dependency>
-    <groupId>software.amazon.awssdk</groupId>
-    <artifactId>sqs</artifactId>
-    <version>2.20.46</version>
-  </dependency>
-  <dependency>
-    <groupId>software.amazon.awssdk</groupId>
-    <artifactId>s3</artifactId>
-    <version>2.20.46</version>
-  </dependency>
-  <!-- https://mvnrepository.com/artifact/software.amazon.awssdk/dynamodb-enhanced -->
-  <dependency>
-    <groupId>software.amazon.awssdk</groupId>
-    <artifactId>dynamodb-enhanced</artifactId>
-    <version>2.20.46</version>
-  </dependency>
-  <!-- https://mvnrepository.com/artifact/software.amazon.awssdk/kinesis -->
-  <dependency>
-    <groupId>software.amazon.awssdk</groupId>
-    <artifactId>kinesis</artifactId>
-    <version>2.20.47</version>
-  </dependency>
+    <!-- Third parties -->
+    <dependency>
+      <groupId>mysql</groupId>
+      <artifactId>mysql-connector-java</artifactId>
+      <scope>runtime</scope>
+      <version>8.0.28</version>
+    </dependency>
+    <dependency>
+      <groupId>org.hsqldb</groupId>
+      <artifactId>hsqldb</artifactId>
+      <scope>runtime</scope>
+      <version>2.7.1</version>
+    </dependency>
+    <dependency>
+      <groupId>org.jolokia</groupId>
+      <artifactId>jolokia-core</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.projectlombok</groupId>
+      <artifactId>lombok</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.micrometer</groupId>
+      <artifactId>micrometer-registry-prometheus</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>de.codecentric</groupId>
+      <artifactId>chaos-monkey-spring-boot</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.json</groupId>
+      <artifactId>json</artifactId>
+      <version>20231013</version>
+    </dependency>
+    <dependency>
+      <groupId>software.amazon.awssdk</groupId>
+      <artifactId>sts</artifactId>
+      <version>2.26.8</version>
+    </dependency>
+    <dependency>
+      <groupId>software.amazon.awssdk</groupId>
+      <artifactId>sqs</artifactId>
+      <version>2.26.8</version>
+    </dependency>
+    <dependency>
+      <groupId>software.amazon.awssdk</groupId>
+      <artifactId>secretsmanager</artifactId>
+      <version>2.26.8</version>
+    </dependency>
+    <dependency>
+      <groupId>software.amazon.awssdk</groupId>
+      <artifactId>bedrockagent</artifactId>
+      <version>2.26.8</version>
+    </dependency>
+    <dependency>
+      <groupId>software.amazon.awssdk</groupId>
+      <artifactId>bedrockruntime</artifactId>
+      <version>2.26.8</version>
+    </dependency>
+    <dependency>
+      <groupId>software.amazon.awssdk</groupId>
+      <artifactId>bedrock</artifactId>
+      <version>2.26.8</version>
+    </dependency>
+    <dependency>
+      <groupId>software.amazon.awssdk</groupId>
+      <artifactId>s3</artifactId>
+      <version>2.26.8</version>
+    </dependency>
+    <!-- https://mvnrepository.com/artifact/software.amazon.awssdk/dynamodb-enhanced -->
+    <dependency>
+      <groupId>software.amazon.awssdk</groupId>
+      <artifactId>dynamodb-enhanced</artifactId>
+      <version>2.26.8</version>
+    </dependency>
+    <!-- https://mvnrepository.com/artifact/software.amazon.awssdk/kinesis -->
+    <dependency>
+      <groupId>software.amazon.awssdk</groupId>
+      <artifactId>kinesis</artifactId>
+      <version>2.26.8</version>
+    </dependency>
 
-  <!-- https://mvnrepository.com/artifact/com.amazonaws/aws-java-sdk-lambda -->
-  <dependency>
-    <groupId>com.amazonaws</groupId>
-    <artifactId>aws-java-sdk-lambda</artifactId>
-    <version>1.12.462</version>
-  </dependency>
+    <!-- https://mvnrepository.com/artifact/com.amazonaws/aws-java-sdk-lambda -->
+    <dependency>
+      <groupId>com.amazonaws</groupId>
+      <artifactId>aws-java-sdk-lambda</artifactId>
+      <version>1.12.749</version>
+    </dependency>
+    <dependency>
+      <groupId>com.amazonaws</groupId>
+      <artifactId>aws-java-sdk-bedrockagent</artifactId>
+      <version>1.12.749</version>
+    </dependency>
 
-  <dependency>
-    <groupId>io.opentelemetry.instrumentation</groupId>
-    <artifactId>opentelemetry-instrumentation-annotations</artifactId>
-    <version>1.22.1</version>
-  </dependency>
+    <dependency>
+      <groupId>com.amazonaws</groupId>
+      <artifactId>aws-java-sdk-bedrock</artifactId>
+      <version>1.12.749</version>
+    </dependency>
 
-  <!-- Testing -->
-  <dependency>
-    <groupId>org.junit.jupiter</groupId>
-    <artifactId>junit-jupiter-api</artifactId>
-    <scope>test</scope>
-  </dependency>
-  <dependency>
-    <groupId>org.junit.jupiter</groupId>
-    <artifactId>junit-jupiter-engine</artifactId>
-    <scope>test</scope>
-  </dependency>
-  <dependency>
-    <groupId>org.assertj</groupId>
-    <artifactId>assertj-core</artifactId>
-    <scope>test</scope>
-  </dependency>
-</dependencies>
+    <dependency>
+      <groupId>com.amazonaws</groupId>
+      <artifactId>aws-java-sdk-bedrockruntime</artifactId>
+      <version>1.12.749</version>
+    </dependency>
 
-<profiles>
-  <profile>
-    <id>buildDocker</id>
-    <build>
-      <plugins>
-        <plugin>
-          <groupId>com.spotify</groupId>
-          <artifactId>docker-maven-plugin</artifactId>
-          <version>${docker.plugin.version}</version>
-        </plugin>
-      </plugins>
-    </build>
-  </profile>
-</profiles>
+    <dependency>
+      <groupId>com.amazonaws</groupId>
+      <artifactId>aws-java-sdk-stepfunctions</artifactId>
+      <version>1.11.749</version>
+    </dependency>
+    <dependency>
+      <groupId>com.amazonaws</groupId>
+      <artifactId>aws-java-sdk-core</artifactId>
+      <version>1.12.749</version>
+    </dependency>
+    <dependency>
+      <groupId>com.amazonaws</groupId>
+      <artifactId>aws-java-sdk-sts</artifactId>
+      <version>1.12.749</version>
+    </dependency>
+    <dependency>
+      <groupId>io.opentelemetry.instrumentation</groupId>
+      <artifactId>opentelemetry-instrumentation-annotations</artifactId>
+      <version>1.22.1</version>
+    </dependency>
+
+    <!-- Testing -->
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <profiles>
+    <profile>
+      <id>buildDocker</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>com.spotify</groupId>
+            <artifactId>docker-maven-plugin</artifactId>
+            <version>${docker.plugin.version}</version>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
 </project>

--- a/spring-petclinic-customers-service/src/main/java/org/springframework/samples/petclinic/customers/aws/BedrockAgentV1Service.java
+++ b/spring-petclinic-customers-service/src/main/java/org/springframework/samples/petclinic/customers/aws/BedrockAgentV1Service.java
@@ -1,0 +1,53 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package org.springframework.samples.petclinic.customers.aws;
+
+import com.amazonaws.auth.WebIdentityTokenCredentialsProvider;
+import com.amazonaws.regions.Regions;
+import com.amazonaws.services.bedrockagent.AWSBedrockAgent;
+import com.amazonaws.services.bedrockagent.AWSBedrockAgentClientBuilder;
+import com.amazonaws.services.bedrockagent.model.*;
+import org.springframework.stereotype.Component;
+import java.util.List;
+@Component
+public class BedrockAgentV1Service {
+    final AWSBedrockAgent bedrockAgentV1Client;
+
+    public BedrockAgentV1Service() {
+        // AWS web identity is set for EKS clusters, if these are not set then use default credentials
+        if (System.getenv("AWS_WEB_IDENTITY_TOKEN_FILE") == null && System.getProperty("aws.webIdentityTokenFile") == null) {
+            bedrockAgentV1Client = AWSBedrockAgentClientBuilder.standard()
+                .withRegion(Regions.US_EAST_1) // replace with your desired region
+                .build();
+        }
+        else {
+            bedrockAgentV1Client = AWSBedrockAgentClientBuilder.standard()
+                .withRegion(Regions.US_EAST_1) // replace with your desired region
+                .withCredentials(WebIdentityTokenCredentialsProvider.create())
+                .build();
+        }
+    }
+
+    public String getKnowledgeBase() {
+        try {
+            ListKnowledgeBasesRequest listRequest = new ListKnowledgeBasesRequest();
+            ListKnowledgeBasesResult listResponse = bedrockAgentV1Client.listKnowledgeBases(listRequest);
+            List<KnowledgeBaseSummary> summaries =listResponse.getKnowledgeBaseSummaries();
+            if(summaries != null && summaries.size() > 0 ) {
+                String knowledgeBaseId = summaries.get(0).getKnowledgeBaseId();
+                System.out.printf("GetKnowledgeBaseRequest: " + knowledgeBaseId);
+                GetKnowledgeBaseRequest request = new GetKnowledgeBaseRequest()
+                        .withKnowledgeBaseId(knowledgeBaseId);
+                GetKnowledgeBaseResult response = bedrockAgentV1Client.getKnowledgeBase(request);
+                System.out.printf("KnowledgeBase ID: " + response.getKnowledgeBase().getName());
+                return response.getKnowledgeBase().getName();
+            } else {
+                return "no knowledge base summaries found";
+            }
+        } catch (Exception e) {
+            System.out.printf("Failed to GetKnowledgeBaseRequest. Error: %s%n", e.getMessage());
+            throw e;
+        }
+    }
+
+}

--- a/spring-petclinic-customers-service/src/main/java/org/springframework/samples/petclinic/customers/aws/BedrockAgentV2Service.java
+++ b/spring-petclinic-customers-service/src/main/java/org/springframework/samples/petclinic/customers/aws/BedrockAgentV2Service.java
@@ -1,0 +1,52 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package org.springframework.samples.petclinic.customers.aws;
+
+import org.springframework.samples.petclinic.customers.Util;
+import org.springframework.stereotype.Component;
+import software.amazon.awssdk.auth.credentials.WebIdentityTokenFileCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.bedrockagent.BedrockAgentClient;
+import software.amazon.awssdk.services.bedrockagent.model.*;
+
+@Component
+public class BedrockAgentV2Service {
+    final BedrockAgentClient bedrockAgentV2Client;
+
+    public BedrockAgentV2Service() {
+        // AWS web identity is set for EKS clusters, if these are not set then use default credentials
+        if (System.getenv("AWS_WEB_IDENTITY_TOKEN_FILE") == null && System.getProperty("aws.webIdentityTokenFile") == null) {
+            bedrockAgentV2Client = BedrockAgentClient.builder()
+                    .region(Region.of(Util.REGION_FROM_EC2))
+                    .build();
+        }
+        else {
+            bedrockAgentV2Client = BedrockAgentClient.builder()
+                    .region(Region.of(Util.REGION_FROM_EKS))
+                    .credentialsProvider(WebIdentityTokenFileCredentialsProvider.create())
+                    .build();
+        }
+
+    }
+
+    public String bedrockAgentGetKnowledgeBaseV2() {
+        try {
+            ListKnowledgeBasesRequest listRequest = ListKnowledgeBasesRequest.builder().build();
+            ListKnowledgeBasesResponse listResponse = bedrockAgentV2Client.listKnowledgeBases(listRequest);
+            if(listResponse.hasKnowledgeBaseSummaries()) {
+                String knowledgeBaseId = listResponse.knowledgeBaseSummaries().get(0).knowledgeBaseId();
+                System.out.printf("GetKnowledgeBaseRequest: " + knowledgeBaseId);
+                GetKnowledgeBaseRequest request = GetKnowledgeBaseRequest.builder()
+                        .knowledgeBaseId(knowledgeBaseId).build();
+                GetKnowledgeBaseResponse response = bedrockAgentV2Client.getKnowledgeBase(request);
+                System.out.printf("KnowledgeBase ID: " + response.knowledgeBase().knowledgeBaseId());
+                return response.knowledgeBase().knowledgeBaseId();
+            } else {
+                return "";
+            }
+        } catch (Exception e) {
+            System.out.printf("Failed to GetKnowledgeBaseRequest! Error: %s%n", e.getMessage());
+            throw e;
+        }
+    }
+}

--- a/spring-petclinic-customers-service/src/main/java/org/springframework/samples/petclinic/customers/aws/BedrockRuntimeV1Service.java
+++ b/spring-petclinic-customers-service/src/main/java/org/springframework/samples/petclinic/customers/aws/BedrockRuntimeV1Service.java
@@ -41,7 +41,7 @@ public class BedrockRuntimeV1Service {
         try {
             System.out.printf("invokeTitanModel: ");
             String modelId = "amazon.titan-text-express-v1";
-            String inputText = "What's the common desease for a pet?";
+            String inputText = "What's the common disease for a pet?";
             float temperature = 0.8f;
             float topP = 0.9f;
             int maxTokenCount = 100;

--- a/spring-petclinic-customers-service/src/main/java/org/springframework/samples/petclinic/customers/aws/BedrockRuntimeV1Service.java
+++ b/spring-petclinic-customers-service/src/main/java/org/springframework/samples/petclinic/customers/aws/BedrockRuntimeV1Service.java
@@ -1,0 +1,86 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package org.springframework.samples.petclinic.customers.aws;
+
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.auth.WebIdentityTokenCredentialsProvider;
+import com.amazonaws.regions.Regions;
+import com.amazonaws.services.bedrockruntime.AmazonBedrockRuntime;
+import com.amazonaws.services.bedrockruntime.AmazonBedrockRuntimeClientBuilder;
+import com.amazonaws.services.bedrockruntime.model.InvokeModelRequest;
+import com.amazonaws.services.bedrockruntime.model.InvokeModelResult;
+import org.json.JSONArray;
+import org.json.JSONObject;
+import org.springframework.stereotype.Component;
+
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+
+@Component
+public class BedrockRuntimeV1Service {
+    final AmazonBedrockRuntime bedrockRuntimeV1Client;
+
+    public BedrockRuntimeV1Service() {
+        // AWS web identity is set for EKS clusters, if these are not set then use default credentials
+        if (System.getenv("AWS_WEB_IDENTITY_TOKEN_FILE") == null && System.getProperty("aws.webIdentityTokenFile") == null) {
+            bedrockRuntimeV1Client = AmazonBedrockRuntimeClientBuilder.standard()
+                    .withRegion(Regions.US_WEST_2) // replace with your desired region
+                    .build();
+        }
+        else {
+            BasicAWSCredentials awsCreds = new BasicAWSCredentials("access_key_id", "secret_key_id");
+            bedrockRuntimeV1Client = AmazonBedrockRuntimeClientBuilder.standard()
+                    .withRegion(Regions.US_WEST_2) // replace with your desired region
+                    .withCredentials(WebIdentityTokenCredentialsProvider.create())
+                    .build();
+        }
+
+    }
+
+    public String invokeTitanModel() {
+        try {
+            System.out.printf("invokeTitanModel: ");
+            String modelId = "amazon.titan-text-express-v1";
+            String inputText = "What's the common desease for a pet?";
+            float temperature = 0.8f;
+            float topP = 0.9f;
+            int maxTokenCount = 100;
+            System.out.printf("Invoke titan Model with modelId: " + modelId + " inputText: " + inputText + " temperature: " + temperature + " topP: " + topP + " maxTokenCount: " + maxTokenCount);
+
+            JSONObject textGenerationConfig = new JSONObject();
+            textGenerationConfig.put("temperature", temperature);
+            textGenerationConfig.put("topP", topP);
+            textGenerationConfig.put("maxTokenCount", maxTokenCount);
+
+            JSONObject nativeRequestObject = new JSONObject();
+            nativeRequestObject.put("inputText", inputText);
+            nativeRequestObject.put("textGenerationConfig", textGenerationConfig);
+
+            String nativeRequest = nativeRequestObject.toString();
+            ByteBuffer buffer = StandardCharsets.UTF_8.encode(nativeRequest);
+
+            InvokeModelRequest invokeModelRequest = new InvokeModelRequest()
+                    .withModelId(modelId)
+                    .withBody(buffer);
+            InvokeModelResult result = bedrockRuntimeV1Client.invokeModel(invokeModelRequest);
+
+            ByteBuffer resultBodyBuffer = result.getBody().asReadOnlyBuffer();
+            byte[] bytes = new byte[resultBodyBuffer.remaining()];
+            resultBodyBuffer.get(bytes);
+            String result_body = new String(bytes, StandardCharsets.UTF_8);
+
+            System.out.printf("Invoke titan Model Result: " + result_body);
+            JSONObject jsonObject = new JSONObject(result_body);
+            int inputTextTokenCount = jsonObject.getInt("inputTextTokenCount");
+            JSONArray resultsArray = jsonObject.getJSONArray("results");
+            JSONObject firstResult = resultsArray.getJSONObject(0);
+            int outputTokenCount = firstResult.getInt("tokenCount");
+            String completionReason = firstResult.getString("completionReason");
+            System.out.printf("Invoke titan Model Result: inputTextTokenCount: " + inputTextTokenCount + " outputTokenCount: " + outputTokenCount + " completionReason: " + completionReason);
+            return "Invoke titan Model Result: " + result_body;
+        } catch (Exception e) {
+            System.out.printf("Invoke titan Model Result: Error: %s%n", e.getMessage());
+            throw e;
+        }
+    }
+}

--- a/spring-petclinic-customers-service/src/main/java/org/springframework/samples/petclinic/customers/aws/BedrockRuntimeV2Service.java
+++ b/spring-petclinic-customers-service/src/main/java/org/springframework/samples/petclinic/customers/aws/BedrockRuntimeV2Service.java
@@ -36,7 +36,7 @@ public class BedrockRuntimeV2Service {
         try {
             System.out.printf("Invoke Anthropic claude: ");
             String claudeModelId = "anthropic.claude-3-sonnet-20240229-v1:0";
-            String prompt = "What's the common desease for a pet?";
+            String prompt = "What's the common disease for a pet?";
             JSONObject userMessage = new JSONObject()
                     .put("role", "user")
                     .put("content", "Pet diagnose content");
@@ -65,12 +65,12 @@ public class BedrockRuntimeV2Service {
 
             JSONObject responseBody = new JSONObject(response.body().asUtf8String());
             System.out.println("invokeLlama2 response:" + response.body().asUtf8String());
-            // String generatedText = responseBody.getString("generation");
-            // int promptTokenCount = responseBody.getInt("prompt_token_count");
-            // int generationTokenCount = responseBody.getInt("generation_token_count");
-            // String stopReason = responseBody.getString("stop_reason");
-            // System.out.printf("Invoke claude Model response: prompt_token_count: " + promptTokenCount + " generation_token_count: " + generationTokenCount + " stop_reason: " + stopReason);
-            return "Done";
+            String generatedText = responseBody.getString("generation");
+            int promptTokenCount = responseBody.getInt("prompt_token_count");
+            int generationTokenCount = responseBody.getInt("generation_token_count");
+            String stopReason = responseBody.getString("stop_reason");
+            System.out.printf("Invoke claude Model response: prompt_token_count: " + promptTokenCount + " generation_token_count: " + generationTokenCount + " stop_reason: " + stopReason);
+            return generatedText;
         } catch (Exception e) {
             System.out.printf("Failed to invoke Anthropic claude: Error: %s%n",e.getMessage());
             throw e;

--- a/spring-petclinic-customers-service/src/main/java/org/springframework/samples/petclinic/customers/aws/BedrockRuntimeV2Service.java
+++ b/spring-petclinic-customers-service/src/main/java/org/springframework/samples/petclinic/customers/aws/BedrockRuntimeV2Service.java
@@ -1,0 +1,79 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package org.springframework.samples.petclinic.customers.aws;
+
+import org.json.JSONArray;
+import org.json.JSONObject;
+import org.springframework.samples.petclinic.customers.Util;
+import org.springframework.stereotype.Component;
+import software.amazon.awssdk.auth.credentials.WebIdentityTokenFileCredentialsProvider;
+import software.amazon.awssdk.core.SdkBytes;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.bedrockruntime.BedrockRuntimeClient;
+import software.amazon.awssdk.services.bedrockruntime.model.*;
+
+@Component
+public class BedrockRuntimeV2Service {
+    final BedrockRuntimeClient bedrockRuntimeV2Client;
+
+    public BedrockRuntimeV2Service() {
+        // AWS web identity is set for EKS clusters, if these are not set then use default credentials
+        if (System.getenv("AWS_WEB_IDENTITY_TOKEN_FILE") == null && System.getProperty("aws.webIdentityTokenFile") == null) {
+            bedrockRuntimeV2Client = BedrockRuntimeClient.builder()
+                    .region(Region.of(Util.REGION_FROM_EC2))
+                    .build();
+        }
+        else {
+            bedrockRuntimeV2Client = BedrockRuntimeClient.builder()
+                    .region(Region.of(Util.REGION_FROM_EKS))
+                    .credentialsProvider(WebIdentityTokenFileCredentialsProvider.create())
+                    .build();
+        }
+
+    }
+
+    public String invokeAnthropicClaude() {
+        try {
+            System.out.printf("Invoke Anthropic claude: ");
+            String claudeModelId = "anthropic.claude-3-sonnet-20240229-v1:0";
+            String prompt = "What's the common desease for a pet?";
+            JSONObject userMessage = new JSONObject()
+                    .put("role", "user")
+                    .put("content", "Pet diagnose content");
+            JSONArray messages = new JSONArray()
+                    .put(userMessage);
+
+            String payload = new JSONObject()
+                    .put("anthropic_version", "bedrock-2023-05-31")
+                    .put("messages", messages)
+                    .put("system", prompt)
+                    .put("max_tokens", 1000)
+                    .put("temperature", 0.5)
+                    .put("top_p", 0.9)
+                    .toString();
+            System.out.printf("Anthropic claude Model with modelId: " + claudeModelId + " prompt: " + prompt + "max_gen_len: 1000 temperature: 0.5 top_p: 0.9");
+
+            InvokeModelRequest request = InvokeModelRequest.builder()
+                    .body(SdkBytes.fromUtf8String(payload))
+                    .modelId(claudeModelId)
+                    .contentType("application/json")
+                    .accept("application/json")
+                    .build();
+            System.out.println("Anthropic claude request:" + request.body().asUtf8String());
+
+            InvokeModelResponse response = bedrockRuntimeV2Client.invokeModel(request);
+
+            JSONObject responseBody = new JSONObject(response.body().asUtf8String());
+            System.out.println("invokeLlama2 response:" + response.body().asUtf8String());
+            // String generatedText = responseBody.getString("generation");
+            // int promptTokenCount = responseBody.getInt("prompt_token_count");
+            // int generationTokenCount = responseBody.getInt("generation_token_count");
+            // String stopReason = responseBody.getString("stop_reason");
+            // System.out.printf("Invoke claude Model response: prompt_token_count: " + promptTokenCount + " generation_token_count: " + generationTokenCount + " stop_reason: " + stopReason);
+            return "Done";
+        } catch (Exception e) {
+            System.out.printf("Failed to invoke Anthropic claude: Error: %s%n",e.getMessage());
+            throw e;
+        }
+    }
+}

--- a/spring-petclinic-customers-service/src/main/java/org/springframework/samples/petclinic/customers/aws/BedrockV1Service.java
+++ b/spring-petclinic-customers-service/src/main/java/org/springframework/samples/petclinic/customers/aws/BedrockV1Service.java
@@ -1,0 +1,53 @@
+package org.springframework.samples.petclinic.customers.aws;
+
+import com.amazonaws.auth.WebIdentityTokenCredentialsProvider;
+import com.amazonaws.regions.Regions;
+import com.amazonaws.services.bedrock.AmazonBedrock;
+import com.amazonaws.services.bedrock.AmazonBedrockClientBuilder;
+import com.amazonaws.services.bedrock.model.*;
+import org.springframework.stereotype.Component;
+import java.util.List;
+
+@Component
+public class BedrockV1Service {
+    final AmazonBedrock bedrockV1Client;
+
+    public BedrockV1Service() {
+        // AWS web identity is set for EKS clusters, if these are not set then use default credentials
+        if (System.getenv("AWS_WEB_IDENTITY_TOKEN_FILE") == null && System.getProperty("aws.webIdentityTokenFile") == null) {
+            bedrockV1Client = AmazonBedrockClientBuilder.standard()
+                    .withRegion(Regions.US_EAST_1) // replace with your desired region
+                    .build();
+        }
+        else {
+            //            BasicAWSCredentials awsCreds = new BasicAWSCredentials("access_key_id", "secret_key_id");
+            bedrockV1Client = AmazonBedrockClientBuilder.standard()
+                    .withRegion(Regions.US_EAST_1) // replace with your desired region
+                    .withCredentials(WebIdentityTokenCredentialsProvider.create())
+                    .build();
+        }
+
+    }
+
+    public String getGuardrail() {
+        String responseString = "No guardrail found";
+        try {
+            ListGuardrailsRequest listRequest = new ListGuardrailsRequest();
+            ListGuardrailsResult listResponse = bedrockV1Client.listGuardrails(listRequest);
+            List<GuardrailSummary> guardrails = listResponse.getGuardrails();
+            if(guardrails != null && guardrails.size() > 0) {
+                String guardRailId = guardrails.get(0).getId();
+                System.out.printf("ListGuardrailsResult: " + guardRailId);
+
+                GetGuardrailRequest request = new GetGuardrailRequest()
+                        .withGuardrailIdentifier(guardRailId);
+                GetGuardrailResult response = bedrockV1Client.getGuardrail(request);
+                responseString = response.toString();
+            }
+        } catch (Exception e) {
+            System.out.printf("Failed to GetGuardrailRequest. Error: %s%n", e.getMessage());
+            throw e;
+        }
+        return "Guardrail ID: " + responseString;
+    }
+}

--- a/spring-petclinic-customers-service/src/main/java/org/springframework/samples/petclinic/customers/aws/BedrockV2Service.java
+++ b/spring-petclinic-customers-service/src/main/java/org/springframework/samples/petclinic/customers/aws/BedrockV2Service.java
@@ -1,0 +1,49 @@
+package org.springframework.samples.petclinic.customers.aws;
+
+import org.springframework.samples.petclinic.customers.Util;
+import org.springframework.stereotype.Component;
+import software.amazon.awssdk.auth.credentials.WebIdentityTokenFileCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.bedrock.BedrockClient;
+import software.amazon.awssdk.services.bedrock.model.*;
+
+@Component
+public class BedrockV2Service {
+    final BedrockClient bedrockV2Client;
+
+    public BedrockV2Service() {
+        // AWS web identity is set for EKS clusters, if these are not set then use default credentials
+        if (System.getenv("AWS_WEB_IDENTITY_TOKEN_FILE") == null && System.getProperty("aws.webIdentityTokenFile") == null) {
+            bedrockV2Client = BedrockClient.builder()
+                    .region(Region.of(Util.REGION_FROM_EC2))
+                    .build();
+        }
+        else {
+            bedrockV2Client = BedrockClient.builder()
+                    .region(Region.of(Util.REGION_FROM_EKS))
+                    .credentialsProvider(WebIdentityTokenFileCredentialsProvider.create())
+                    .build();
+        }
+    }
+    public String getGuardrail() {
+        String id = "";
+        try {
+            ListGuardrailsRequest listRequest =ListGuardrailsRequest.builder().build();
+            ListGuardrailsResponse listResponse = bedrockV2Client.listGuardrails(listRequest);
+            if(listResponse.hasGuardrails()) {
+                String guardRailId = listResponse.guardrails().get(0).id();
+                System.out.printf("ListGuardrailsRequest: " + guardRailId);
+
+                GetGuardrailRequest request = GetGuardrailRequest.builder()
+                        .guardrailIdentifier(guardRailId).build();
+                GetGuardrailResponse response = bedrockV2Client.getGuardrail(request);
+                return response.guardrailId();
+            } else {
+                return "";
+            }
+        } catch (Exception e) {
+            System.out.printf("Failed to GetGuardrailRequest. Error: %s%n", e.getMessage());
+            throw e;
+        }
+    }
+}

--- a/spring-petclinic-customers-service/src/main/java/org/springframework/samples/petclinic/customers/web/PetResource.java
+++ b/spring-petclinic-customers-service/src/main/java/org/springframework/samples/petclinic/customers/web/PetResource.java
@@ -24,8 +24,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
-import org.springframework.samples.petclinic.customers.aws.KinesisService;
-import org.springframework.samples.petclinic.customers.aws.SqsService;
+import org.springframework.samples.petclinic.customers.aws.*;
 import org.springframework.samples.petclinic.customers.model.*;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.client.RestTemplate;
@@ -51,7 +50,13 @@ class PetResource {
     private final OwnerRepository ownerRepository;
     private final SqsService sqsService;
     private final KinesisService kinesisService;
-    
+    private final BedrockAgentV1Service bedrockAgentV1Service;
+    private final BedrockAgentV2Service bedrockAgentV2Service;
+    private final BedrockRuntimeV1Service bedrockRuntimeV1Service;
+    private final BedrockRuntimeV2Service bedrockRuntimeV2Service;
+    private final BedrockV1Service bedrockV1Service;
+    private final BedrockV2Service bedrockV2Service;
+
     @Autowired
     private RestTemplate restTemplate;
 
@@ -78,6 +83,30 @@ class PetResource {
             throw e;
         }
         return save(pet, petRequest);
+    }
+
+    @GetMapping("/diagnose/owners/*/pets/{petId}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public void processDiagnose(@PathVariable("petId") int petId) {
+        log.info("bedrockAgentV1Service Getting knowledge base");
+        bedrockAgentV1Service.getKnowledgeBase();
+        log.info("bedrockAgentV1Service FINISH Getting knowledge base");
+        log.info("bedrockV1Service Getting guardrail");
+        bedrockV1Service.getGuardrail();
+        log.info("bedrockV1Service FINISH Getting guardrail");
+        log.info("DEBUG: CALLING BEDROCK petId = " + petId);
+        log.info("DEBUG: bedrockRuntimeV1Service Invoking Titan model");
+        bedrockRuntimeV1Service.invokeTitanModel();
+        log.info("bedrockRuntimeV1Service FINISH Invoking Titan model");
+        log.info("bedrockAgentV2Service Getting knowledge base");
+        bedrockAgentV2Service.bedrockAgentGetKnowledgeBaseV2();
+        log.info("bedrockAgentV2Service FINISH Getting knowledge base");
+        log.info("bedrockV2Service Getting guardrail");
+        bedrockV2Service.getGuardrail();
+        log.info("bedrockV2Service FINISH Getting guardrail");
+        log.info("bedrockRuntimeV2Service Invoking Anthropic claude");
+        bedrockRuntimeV2Service.invokeAnthropicClaude();
+        log.info("bedrockRuntimeV2Service FINISH Invoking Anthropic claude");
     }
 
     @PutMapping("/owners/*/pets/{petId}")

--- a/spring-petclinic-customers-service/src/test/java/org/springframework/samples/petclinic/customers/web/PetResourceTest.java
+++ b/spring-petclinic-customers-service/src/test/java/org/springframework/samples/petclinic/customers/web/PetResourceTest.java
@@ -24,8 +24,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
-import org.springframework.samples.petclinic.customers.aws.KinesisService;
-import org.springframework.samples.petclinic.customers.aws.SqsService;
+import org.springframework.samples.petclinic.customers.aws.*;
 import org.springframework.samples.petclinic.customers.model.Owner;
 import org.springframework.samples.petclinic.customers.model.OwnerRepository;
 import org.springframework.samples.petclinic.customers.model.Pet;
@@ -67,6 +66,24 @@ class PetResourceTest {
 
     @MockBean
     RestTemplate restTemplate;
+
+    @MockBean
+    BedrockAgentV1Service bedrockAgentV1Service;
+
+    @MockBean
+    BedrockAgentV2Service bedrockAgentV2Service;
+
+    @MockBean
+    BedrockRuntimeV1Service bedrockRuntimeV1Service;
+
+    @MockBean
+    BedrockRuntimeV2Service bedrockRuntimeV2Service;
+
+    @MockBean
+    BedrockV1Service bedrockV1Service;
+
+    @MockBean
+    BedrockV2Service bedrockV2Service;
 
     @Test
     void shouldGetAPetInJSonFormat() throws Exception {

--- a/terraform/eks/main.tf
+++ b/terraform/eks/main.tf
@@ -167,7 +167,7 @@ module "demo_service_account" {
   create_role                   = true
   role_name                     = "DemoServiceRole-${var.cluster_name}"
   provider_url                  = replace(module.eks.oidc_provider, "https://", "")
-  role_policy_arns              = ["arn:aws:iam::aws:policy/AmazonSQSFullAccess", "arn:aws:iam::aws:policy/AmazonS3FullAccess", "arn:aws:iam::aws:policy/AmazonKinesisFullAccess", "arn:aws:iam::aws:policy/AmazonDynamoDBFullAccess"]
+  role_policy_arns              = ["arn:aws:iam::aws:policy/AmazonSQSFullAccess", "arn:aws:iam::aws:policy/AmazonS3FullAccess", "arn:aws:iam::aws:policy/AmazonKinesisFullAccess", "arn:aws:iam::aws:policy/AmazonDynamoDBFullAccess", "arn:aws:iam::aws:policy/AmazonBedrockFullAccess"]
   oidc_fully_qualified_subjects = ["system:serviceaccount:default:visits-service-account"]
 }
 

--- a/traffic-generator/index.js
+++ b/traffic-generator/index.js
@@ -83,6 +83,19 @@ const invalidRequestTask = cron.schedule('* * * * *', () => {
 
 invalidRequestTask.start();
 
+const bedrockRequestTask = cron.schedule('* * * * *', () => {
+    const lowLoad = getRandomNumber(1, 2);
+    for (let i = 0; i < lowLoad; i++) {
+        sleep(5*1000);
+        console.log('calling bedrock: ' + (i + 1))
+        axios.get(`${baseUrl}/api/customer/diagnose/owners/1/pets/1`, { timeout: 30000 })
+            .catch(err => {
+                console.error("Failed to get /api/customer/diagnose/owners/1/pets/1, error: " + (err.response ? err.response.data : err.toString()));
+            }); // Catch and log errors
+    }
+}, { scheduled: false });
+
+bedrockRequestTask.start();
 
 
 const createOwnerLowTrafficTask = cron.schedule('* * * * *', () => {


### PR DESCRIPTION
*Description of changes:*
Add Bedrock & Bedrock runtime API call examples for feel and trial purpose. The major changes are
1. Added a new `customer/diagnose/owners/*` API in gateway service for Bedrock api invokes'
2. Extended customer service to
   * call BedrockAgent via AWS SDK v1 and v2
   * call Bedrock runtime via AWS SDK v1 on Titian model and v2 on Claude model
   * call bedrock via AWS SDK v1 and v2 for Guardrails APIs

<img width="941" alt="image" src="https://github.com/user-attachments/assets/d0289d0b-48d7-4459-bbe0-40d408783dd1">

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

