### PR TITLE
Upgrade Cloudwatch Observability add-on version

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ Please be aware that this sample application includes a publicly accessible Appl
    ``` shell
 
    export TF_VAR_cluster_name=app-signals-demo
-   export TF_VAR_cloudwatch_observability_addon_version=v1.5.1-eksbuild.1
+   export TF_VAR_cloudwatch_observability_addon_version=v1.10.0-eksbuild.2
 
    terraform init -backend-config="bucket=${TFSTATE_BUCKET}" -backend-config="key=${TFSTATE_KEY}" -backend-config="region=${TFSTATE_REGION}"
 


### PR DESCRIPTION
*Issue #, if available:*
#48 

*Description of changes:*
In order to use CloudWatch Application Signals, the Cloudwatch Observability Addon version requires v1.7.0-eksbuild.1, but it's v1.5.1-eksbuild.1 in the readme.
Therefore, I have changed to the current latest version.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

