### PR TITLE
Consolidate ECS tasks to share the same IAM roles.

### DIFF
--- a/scripts/ecs/appsignals/sample-app/task-definitions/spring-petclinic-api-gateway.json
+++ b/scripts/ecs/appsignals/sample-app/task-definitions/spring-petclinic-api-gateway.json
@@ -138,6 +138,6 @@
       "name": "opentelemetry-auto-instrumentation"
     }
   ],
-  "taskRoleArn": "arn:aws:iam::000111222333:role/ecs-demo-task-role-region-name",
-  "executionRoleArn": "arn:aws:iam::000111222333:role/ec2-demo-execution-role-region-name"
+  "taskRoleArn": "arn:aws:iam::000111222333:role/ecs-pet-clinic-task-role-region-name",
+  "executionRoleArn": "arn:aws:iam::000111222333:role/ecs-pet-clinic-execution-role-region-name"
 }

--- a/scripts/ecs/appsignals/sample-app/task-definitions/spring-petclinic-billing-service.json
+++ b/scripts/ecs/appsignals/sample-app/task-definitions/spring-petclinic-billing-service.json
@@ -165,6 +165,6 @@
       "name": "opentelemetry-auto-instrumentation-python"
     }
   ],
-  "taskRoleArn": "arn:aws:iam::000111222333:role/ecs-demo-task-role-region-name",
-  "executionRoleArn": "arn:aws:iam::000111222333:role/ec2-demo-execution-role-region-name"
+  "taskRoleArn": "arn:aws:iam::000111222333:role/ecs-pet-clinic-task-role-region-name",
+  "executionRoleArn": "arn:aws:iam::000111222333:role/ecs-pet-clinic-execution-role-region-name"
 }

--- a/scripts/ecs/appsignals/sample-app/task-definitions/spring-petclinic-customers-service.json
+++ b/scripts/ecs/appsignals/sample-app/task-definitions/spring-petclinic-customers-service.json
@@ -138,6 +138,6 @@
       "name": "opentelemetry-auto-instrumentation"
     }
   ],
-  "taskRoleArn": "arn:aws:iam::000111222333:role/ecs-demo-task-role-region-name",
-  "executionRoleArn": "arn:aws:iam::000111222333:role/ec2-demo-execution-role-region-name"
+  "taskRoleArn": "arn:aws:iam::000111222333:role/ecs-pet-clinic-task-role-region-name",
+  "executionRoleArn": "arn:aws:iam::000111222333:role/ecs-pet-clinic-execution-role-region-name"
 }

--- a/scripts/ecs/appsignals/sample-app/task-definitions/spring-petclinic-insurance-service.json
+++ b/scripts/ecs/appsignals/sample-app/task-definitions/spring-petclinic-insurance-service.json
@@ -175,6 +175,6 @@
       "name": "opentelemetry-auto-instrumentation-python"
     }
   ],
-  "taskRoleArn": "arn:aws:iam::000111222333:role/ecs-demo-task-role-region-name",
-  "executionRoleArn": "arn:aws:iam::000111222333:role/ec2-demo-execution-role-region-name"
+  "taskRoleArn": "arn:aws:iam::000111222333:role/ecs-pet-clinic-task-role-region-name",
+  "executionRoleArn": "arn:aws:iam::000111222333:role/ecs-pet-clinic-execution-role-region-name"
 }

--- a/scripts/ecs/appsignals/sample-app/task-definitions/spring-petclinic-vets-service.json
+++ b/scripts/ecs/appsignals/sample-app/task-definitions/spring-petclinic-vets-service.json
@@ -138,6 +138,6 @@
       "name": "opentelemetry-auto-instrumentation"
     }
   ],
-  "taskRoleArn": "arn:aws:iam::000111222333:role/ecs-demo-task-role-region-name",
-  "executionRoleArn": "arn:aws:iam::000111222333:role/ec2-demo-execution-role-region-name"
+  "taskRoleArn": "arn:aws:iam::000111222333:role/ecs-pet-clinic-task-role-region-name",
+  "executionRoleArn": "arn:aws:iam::000111222333:role/ecs-pet-clinic-execution-role-region-name"
 }

--- a/scripts/ecs/appsignals/sample-app/task-definitions/spring-petclinic-visits-service.json
+++ b/scripts/ecs/appsignals/sample-app/task-definitions/spring-petclinic-visits-service.json
@@ -138,6 +138,6 @@
       "name": "opentelemetry-auto-instrumentation"
     }
   ],
-  "taskRoleArn": "arn:aws:iam::000111222333:role/ecs-demo-task-role-region-name",
-  "executionRoleArn": "arn:aws:iam::000111222333:role/ec2-demo-execution-role-region-name"
+  "taskRoleArn": "arn:aws:iam::000111222333:role/ecs-pet-clinic-task-role-region-name",
+  "executionRoleArn": "arn:aws:iam::000111222333:role/ecs-pet-clinic-execution-role-region-name"
 }

--- a/scripts/ecs/appsignals/sample-app/task-definitions/traffic-generator.json
+++ b/scripts/ecs/appsignals/sample-app/task-definitions/traffic-generator.json
@@ -52,6 +52,6 @@
       }
     }
   ],
-  "taskRoleArn": "arn:aws:iam::007003802740:role/ecs-demo-task-role-region-name",
-  "executionRoleArn": "arn:aws:iam::007003802740:role/ec2-demo-execution-role-region-name"
+  "taskRoleArn": "arn:aws:iam::000111222333:role/ecs-pet-clinic-task-role-region-name",
+  "executionRoleArn": "arn:aws:iam::000111222333:role/ecs-pet-clinic-execution-role-region-name"
 }

--- a/scripts/ecs/appsignals/setup-ecs-demo.sh
+++ b/scripts/ecs/appsignals/setup-ecs-demo.sh
@@ -53,7 +53,7 @@ SUBNET_IDS=""
 SECURITY_GROUP_ID=""
 LOAD_BALANCER_ARN=""
 LOAD_BALANCER_DNS=""
-ECR_IMAGE_PREFIX="""
+ECR_IMAGE_PREFIX=""
 
 
 function create_resources() {


### PR DESCRIPTION
This PR is a fix on PR: https://github.com/aws-observability/application-signals-demo/pull/59, to consolidate ECS tasks to share the same IAM roles.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

