### PR TITLE
use different spring profile for api gateway

### DIFF
--- a/scripts/eks/appsignals/sample-app/api-gateway-deployment.yaml
+++ b/scripts/eks/appsignals/sample-app/api-gateway-deployment.yaml
@@ -39,5 +39,12 @@ spec:
           name: api-gateway-java
           ports:
             - containerPort: 8080
+          env:
+            - name: CONFIG_SERVER_URL
+              value: http://config-server:8888
+            - name: DISCOVERY_SERVER_URL
+              value: http://discovery-server:8761/eureka
+            - name: SPRING_PROFILES_ACTIVE
+              value: prod
       restartPolicy: Always
 status: {}

--- a/scripts/k8s/appsignals/sample-app/api-gateway-deployment.yaml
+++ b/scripts/k8s/appsignals/sample-app/api-gateway-deployment.yaml
@@ -39,5 +39,12 @@ spec:
           name: api-gateway-java
           ports:
             - containerPort: 8080
+          env:
+            - name: CONFIG_SERVER_URL
+              value: http://config-server:8888
+            - name: DISCOVERY_SERVER_URL
+              value: http://discovery-server:8761/eureka
+            - name: SPRING_PROFILES_ACTIVE
+              value: prod
       restartPolicy: Always
 status: {}


### PR DESCRIPTION
*Issue #, if available:*

We found a strange issue with the pet-clinic frontend microservice: it can't forward traffic to other microservice because the load balancer used by spring application failed to work with the discovery server. This issue seems to started on Nov 25. We don't know exactly the root cause. (If you have a running sample app in EKS, you will observe this issue by simply restarting the pods. In this case, you have no external changes but the issue will show up. We have done pod restarting multiple times previously but never saw this issue. So it's really mysterious what triggered it) 

*Description of changes:*
To workaround this issue, we use a different spring profile and setting the config server and discovery server as environmental variables in the deployment yaml files. This is similar to what we do in EC2 set up and we know it's working. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

