### PR TITLE
Add exit 1 for failed cdk and also update ECS DB credential name

### DIFF
--- a/cdk/ec2/ec2-cdk.sh
+++ b/cdk/ec2/ec2-cdk.sh
@@ -43,6 +43,7 @@ if [[ "$ACTION" == "deploy" ]]; then
   else
     echo "Deployment failed. Attempting to clean up resources by destroying all stacks..."
     cdk destroy --all --force --verbose
+    exit 1
   fi
 elif [[ "$ACTION" == "destroy" ]]; then
   echo "Starting CDK destroy for all stacks in the app"

--- a/cdk/ecs/ecs-cdk.sh
+++ b/cdk/ecs/ecs-cdk.sh
@@ -45,6 +45,7 @@ if [[ "$ACTION" == "deploy" ]]; then
   else
     echo "Deployment failed. Attempting to clean up resources by destroying all stacks..."
     cdk destroy --all --force --verbose
+    exit 1
   fi
 elif [[ "$ACTION" == "destroy" ]]; then
   echo "Starting CDK destroy for all stacks in the app"

--- a/cdk/ecs/lib/stacks/databaseStack.ts
+++ b/cdk/ecs/lib/stacks/databaseStack.ts
@@ -40,7 +40,7 @@ export class RdsDatabaseStack extends Stack {
 
         // Create a Secret for the database credentials
         this.dbSecret = new Secret(this, 'DBSecret', {
-            secretName: 'PetClinicDBCredentials',
+            secretName: 'ECSPetClinicDBCredentials',
             generateSecretString: {
                 secretStringTemplate: JSON.stringify({ username: 'root' }),
                 generateStringKey: 'password',

--- a/cdk/eks/eks-cdk.sh
+++ b/cdk/eks/eks-cdk.sh
@@ -48,10 +48,12 @@ if [[ "$ACTION" == "deploy" ]]; then
     else
       echo "Synthetic canary and SLO failed to deploy"
       cdk destroy --context enableSlo=True --all --force --verbose
+      exit 1
     fi
   else
     echo "Deployment failed. Attempting to clean up resources by destroying all stacks..."
     cdk destroy --all --force --verbose
+    exit 1
   fi
 elif [[ "$ACTION" == "destroy" ]]; then
   echo "Starting CDK destroy for all stacks in the app"


### PR DESCRIPTION
*Issue #, if available:*
CDK deployment bash script indicates success despite failing. Also, there is a conflict between EC2 and ECS CDK due to sharing the same db credential name

*Description of changes:*
- Add exit 1 to all failed cdk deployment. 
- Update ECS db credential secret name

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

