### PR TITLE
Specify required Java version to build images.

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ This code for sample application is intended for demonstration purposes only. It
 * jq is installed - https://jqlang.github.io/jq/download/
 * AWS CDK >= v2.166.0 is installed - https://docs.aws.amazon.com/cdk/v2/guide/getting_started.html#getting_started_install
 * Node.js >= v18.0.0 is installed.
+* Java 11 is installed.
 * [Optional] If you plan to install the infrastructure resources using Terraform, terraform cli is required. https://developer.hashicorp.com/terraform/tutorials/aws-get-started/install-cli
 * [Optional] If you want to try out AWS Bedrock/GenAI support with Application Signals, enable Amazon Titian, Anthropic Claude, Meta Llama foundation models by following the instructions in https://docs.aws.amazon.com/bedrock/latest/userguide/model-access.html
 # EKS demo


### PR DESCRIPTION
*Issue #, if available:*
I was getting the following error:
```
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-compiler-plugin:3.8.1:compile (default-compile) on project spring-petclinic-customers-service: Fatal error compiling: java.lang.NoSuchFieldError: Class com.sun.tools.javac.tree.JCTree$JCImport does not have member field 'com.sun.tools.javac.tree.JCTree qualid' -> [Help 1]
```

By using Java 11 instead of Java 21, I was able to successfully build the images on my machine. 

*Description of changes:*
Update README to specify which version of Java is required.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

