### PR TITLE
Fix typo in setup-eks-demo.sh

### DIFF
--- a/scripts/eks/appsignals/setup-eks-demo.sh
+++ b/scripts/eks/appsignals/setup-eks-demo.sh
@@ -30,7 +30,7 @@ export AWS_DEFAULT_REGION=$REGION
 function run_cdk() {
   echo "Running CDK..."
   # jump to the cdk folder, run the cdk commands, and then jump back to current folder
-  pushd ../../../cdk/ecs >/dev/null
+  pushd ../../../cdk/eks >/dev/null
   ./eks-cdk.sh $1
   popd >/dev/null
 }


### PR DESCRIPTION
*Issue #, if available:*
The script is pointing to ecs rather than EKS. 
Also updating the permission of the file with `chmod +x` so that it's executable

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

