### PR TITLE
Fix RDS import issue and solve divergent aws-cdk and aws-cdk-lib version risk

### DIFF
--- a/cdk/eks/lib/stacks/rds-stack.ts
+++ b/cdk/eks/lib/stacks/rds-stack.ts
@@ -5,7 +5,7 @@ import { SubnetGroup, DatabaseCluster, DatabaseClusterEngine, AuroraPostgresEngi
 import { InstanceType, InstanceClass, InstanceSize} from 'aws-cdk-lib/aws-ec2';
 import { Secret } from 'aws-cdk-lib/aws-secretsmanager';
 import { Vpc, SecurityGroup } from 'aws-cdk-lib/aws-ec2';
-import { DatabaseInsightsMode } from 'aws-cdk-lib/aws-rds/lib/cluster';
+import { DatabaseInsightsMode } from 'aws-cdk-lib/aws-rds';
 
 interface RdsStackProps extends StackProps {
   vpc: Vpc;

--- a/cdk/eks/package.json
+++ b/cdk/eks/package.json
@@ -17,7 +17,7 @@
     "@types/jest": "^29.5.14",
     "@types/js-yaml": "^4.0.9",
     "@types/node": "22.7.9",
-    "aws-cdk": "2.179.0",
+    "aws-cdk": "^2.179.0",
     "jest": "^29.7.0",
     "ts-jest": "^29.2.5",
     "ts-node": "^10.9.2",


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/aws-cdk/issues/32775
*Description of changes:*
Fix RDS import issue and solve divergent aws-cdk and aws-cdk-lib version risk, which means, aws-cdk version will start from 2.1000 now and will no longer same as aws-cdk-lib version (example: 2.179/2.180)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

