### PR TITLE
fix: update HttpErrorCount metric for RUM

### DIFF
--- a/cdk/eks/lib/stacks/rum-stack.ts
+++ b/cdk/eks/lib/stacks/rum-stack.ts
@@ -127,7 +127,7 @@ export class CloudWatchRumStack extends Stack {
         dimensionKeys: {
           'metadata.pageId': 'PageId',
         },
-        eventPattern: '{"event_type":["com.amazon.rum.http_event"],"metadata":{"pageId":["/welcome"]}}',
+        eventPattern: '{"event_type":["com.amazon.rum.http_event"],"metadata":{"pageId":["/welcome"]},"event_details":{"response":{"status":[{"numeric":[">=",400]}]}}}',
       },
       {
         name: 'WebVitalsLargestContentfulPaint',


### PR DESCRIPTION
fix: update HttpErrorCount metric for RUM

*Description of changes:*
Recently a RUM backend change was made in CFN to fix the HttpErrorCount metric. Updating the code to satisfy those validations which is causing the EKS build to fail.

```
Resource handler returned message: "Invalid request provided: ErrorCode: ValidationException,ErrorMessage: Value {} for metric field event detail is not valid.,MetricDefinition: MetricDefinition(name=HttpErrorCount, namespace=AWS/RUM, valueKey=null, unitLabel=Count, dimensionKeys={metadata.pageId=PageId}, eventPattern={"event_type":["com.amazon.rum.http_event"],"metadata":{"pageId":["/welcome"]}})" (RequestToken: 05efcf86-b4d1-e2c1-3278-a4a39e692549, HandlerErrorCode: InvalidRequest)
````

*Testing:* Built the changes locally to personal account.

![image](https://github.com/user-attachments/assets/eff67d02-ced6-4f4a-bdfe-94f6a9ae69cf)

![image](https://github.com/user-attachments/assets/0c1326b9-b2fe-434d-a1b2-fbd636802905)



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

