### PR TITLE
Fix health check and update doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,20 @@ export REGION='us-east-1'
    cd scripts/eks/appsignals && ./setup-eks-demo.sh --region=region-name
    ``` 
 
-2. Clean up after you are done with the sample app. Replace `region-name` with the same value that you use in previous step.
+2. Access the EKS cluster using kubectl to check pod status and logs:
+
+   ```shell
+   # Configure kubectl to use the EKS cluster
+   aws eks update-kubeconfig --name eks-pet-clinic-demo --region <your-region> --role-arn arn:aws:iam::<your-account>:role/PetClinicEksClusterRole
+
+   # View the microservices pods
+   kubectl get pods -n pet-clinic
+
+   # Get the ingress URL
+   kubectl get svc -n ingress-nginx | grep "ingress-nginx" | awk '{print $4}'
+   ```
+
+3. Clean up after you are done with the sample app. Replace `region-name` with the same value that you use in previous step.
    ```
    cd scripts/eks/appsignals/ && ./setup-eks-demo.sh --operation=delete --region=region-name
    ```

--- a/cdk/eks/lib/manifests/sample-app/billing-service-deployment.yaml
+++ b/cdk/eks/lib/manifests/sample-app/billing-service-deployment.yaml
@@ -53,8 +53,16 @@ spec:
           imagePullPolicy: Always
           livenessProbe:
             httpGet:
-              path: /billings/
+              path: /health/
               port: 8800
-            initialDelaySeconds: 3
+            initialDelaySeconds: 10
             periodSeconds: 60
+            timeoutSeconds: 5
+          readinessProbe:
+            httpGet:
+              path: /health/
+              port: 8800
+            initialDelaySeconds: 10
+            periodSeconds: 15
+            timeoutSeconds: 5
       restartPolicy: Always


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

* Change the health check setting to use a different url path (`/health`). The previous path `/billings` is pretty heavy and has a high latency which will cause the pod to restart continuously due to health check failure
* Add instruction on how to access the EKS cluster


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

