### PR TITLE
change eureka setting for payment service

### DIFF
--- a/cdk/eks/lib/manifests/sample-app/payment-service-deployment.yaml
+++ b/cdk/eks/lib/manifests/sample-app/payment-service-deployment.yaml
@@ -34,6 +34,12 @@ spec:
               value: "true"
             - name: eureka__instance__port
               value: "8089"
+            - name: eureka__client__eurekaServerConnectTimeoutSeconds
+              value: "30"
+            - name: eureka__client__eurekaServerReadTimeoutSeconds
+              value: "30"
+            - name: eureka__client__registryFetchIntervalSeconds
+              value: "30"
 
           ports:
             - containerPort: 8089


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

The default setting for eureka client sometimes fail due to connection timeout. This will cause the payment service to keep restarting. We want to use more relaxed settings instead. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

