### PR TITLE
fix image build in CDK

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ cdk deploy     # Deploys the CodeBuild stack to the specified region
 2. Trigger a build to create and push all images to ECR. Replace `region-name` with the region you choose (e.g. `us-east-1`)
 
 ``` shell
-./scripts/trigger-build.sh --region=region-name 
+./scripts/trigger-build.sh --region region-name 
 ```
 
 For more details, see the [CodeBuild README](cdk/codebuild/README.md).

--- a/lambda-petclinic/cdk/lib/lambda-version-resource.ts
+++ b/lambda-petclinic/cdk/lib/lambda-version-resource.ts
@@ -53,8 +53,9 @@ export class LambdaVersioning extends Construct {
           image: lambda.Runtime.NODEJS_20_X.bundlingImage,
           command: [
             'bash', '-c',
-            'npm install && cp -r . /asset-output/'
+            'npm install --production --no-optional --no-audit && cp -r . /asset-output/'
           ],
+          user: 'root',
         }
       }),
       timeout: cdk.Duration.minutes(5),

--- a/lambda-petclinic/cdk/tsconfig.json
+++ b/lambda-petclinic/cdk/tsconfig.json
@@ -20,5 +20,6 @@
     "strictPropertyInitialization": false,
     "typeRoots": ["./node_modules/@types"]
   },
-  "exclude": ["node_modules", "cdk.out"]
+  "include": ["bin/**/*", "lib/**/*"],
+  "exclude": ["node_modules", "cdk.out", "dist"]
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Fix the image build issue due to permissions: 

```
ValidationError: Failed to bundle asset LambdaPetClinicStack/GetAppointmentVersioning/VersionHandler/Code/Stage, bundle output is located at
  /local/home/pinxiang/test-slo/application-signals-demo/lambda-petclinic/cdk/cdk.out/asset.64f06d48a4bd71ee4b9d3d88aa28f6289151032ee882cb15165894818dec02be-building: ExecutionError: docker exited with
  status 243
  --> Command: docker run --rm -u "11896572:100" -v "/local/home/pinxiang/test-slo/application-signals-demo/lambda-petclinic/cdk/src/lambda-version-handler:/asset-input:delegated" -v
  "/local/home/pinxiang/test-slo/application-signals-demo/lambda-petclinic/cdk/cdk.out/asset.64f06d48a4bd71ee4b9d3d88aa28f6289151032ee882cb15165894818dec02be-building:/asset-output:delegated" -w
  "/asset-input" "public.ecr.aws/sam/build-nodejs20.x" bash -c "npm install && cp -r . /asset-output/"
      at path [LambdaPetClinicStack/GetAppointmentVersioning/VersionHandler/Code/Stage] in aws-cdk-lib.AssetStaging
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

