### PR TITLE
Update Ai Validator Docker Base Image

### DIFF
--- a/ai-validator/cdk/Dockerfile
+++ b/ai-validator/cdk/Dockerfile
@@ -1,5 +1,5 @@
 # Base image
-FROM --platform=linux/amd64 amazonlinux:2023
+FROM public.ecr.aws/amazonlinux/amazonlinux:2023
 
 # Install dependencies
 RUN yum update -y && \


### PR DESCRIPTION
*Issue #, if available:*
Pulling the base image without authenticating into docker may cause errors such as `toomanyrequests`

*Description of changes:*
Pull the image from AWS public ECR rather than docker

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

