### PR TITLE
Update ai validator ecs configuration

### DIFF
--- a/ai-validator/cdk/ecs.ts
+++ b/ai-validator/cdk/ecs.ts
@@ -102,6 +102,7 @@ export class AIValidatorStack extends cdk.Stack {
         cpu: 4096,
         memoryLimitMiB: 8192,
         taskRole,
+        ephemeralStorageGiB: 40,
       });
 
       taskDef.addContainer(`AITestContainer-${testId}`, {
@@ -162,7 +163,7 @@ export class AIValidatorStack extends cdk.Stack {
         evaluationPeriods: 1,
         comparisonOperator:
           cloudwatch.ComparisonOperator.GREATER_THAN_OR_EQUAL_TO_THRESHOLD,
-        treatMissingData: cloudwatch.TreatMissingData.NOT_BREACHING,
+        treatMissingData: cloudwatch.TreatMissingData.BREACHING,
       });
 
       failureAlarms.push(alarm);


### PR DESCRIPTION
*Issue #, if available:*
The ECS tasks are failing due to not enough disk space. Also the alarms are showing as success despite no metrics being available due to the ECS task failures

*Description of changes:*
- Increased ECS disk space from 20gib to 40 gib
- Changing alarm to consider missing data point as breaching

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

