### PR TITLE
remove cloud9 from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,9 +35,6 @@ This code for sample application is intended for demonstration purposes only. It
 
 ## Deploy via Shell Scripts
 
-Note that if you want to run the scripts in a shell inside an [AWS Cloud9](https://docs.aws.amazon.com/cloud9/latest/user-guide/welcome.html) environment, you need to ensure the environment has sufficient disk space, as building images can consume a lot of space. To increase the disk size to 50 GB, follow the instructions here: [Resize Cloud9 Environment](https://docs.aws.amazon.com/cloud9/latest/user-guide/move-environment.html#move-environment-resize). Additionally, you need to disable AWS managed temporary credentials to avoid credential renewal interfering with script execution. Instructions can be found here: [Disable AWS managed temporary credentials](https://catalog.workshops.aws/observability/en-US/workshopstudio/setup-cloud9#disable-aws-managed-temporary-credentials).
-
-
 ### Build the sample application images and push to ECR
 
 #### Option 1: Using AWS CodeBuild (Recommended - No Local Build Environment Required)


### PR DESCRIPTION

*Issue #, if available:*

*Description of changes:*

Remove cloud9 as it is deprecated. We don't need to use it anymore. People can use the AWS codebuild to build the image.



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

