### PR TITLE
Update Pet Clinic AI Agent ADOT version and set Region for Invoke Agent

### DIFF
--- a/cdk/agents/lambda/traffic-generator/traffic_generator.py
+++ b/cdk/agents/lambda/traffic-generator/traffic_generator.py
@@ -1,6 +1,7 @@
 import json
 import os
 import random
+import uuid
 import urllib.parse as urlparse
 from urllib.request import Request, urlopen
 import boto3
@@ -15,6 +16,9 @@ def lambda_handler(event, context):
     primary_agent_arn = os.environ.get('PRIMARY_AGENT_ARN')
     nutrition_agent_arn = os.environ.get('NUTRITION_AGENT_ARN')
     num_requests = int(os.environ.get('REQUESTS_PER_INVOKE', '20'))
+    
+    # Use environment variable session ID or generate one
+    session_id = os.environ.get('SESSION_ID', f"pet-clinic-session-{str(uuid.uuid4())}")
 
     if not primary_agent_arn:
         return {
@@ -30,10 +34,10 @@ def lambda_handler(event, context):
         
         if is_nutrition_query:
             query = random.choice(prompts['nutrition-queries'])
-            enhanced_query = f"{query}\n\nNote: Our nutrition specialist agent ARN is {nutrition_agent_arn}" if nutrition_agent_arn else query
+            enhanced_query = f"{query}\n\nSession ID: {session_id}\nNote: Our nutrition specialist agent ARN is {nutrition_agent_arn}" if nutrition_agent_arn else f"{query}\n\nSession ID: {session_id}"
         else:
             query = random.choice(prompts['non-nutrition-queries'])
-            enhanced_query = query
+            enhanced_query = f"{query}\n\nSession ID: {session_id}"
 
         try:
             encoded_arn = urlparse.quote(primary_agent_arn, safe='')

--- a/cdk/agents/lib/pet-clinic-agents-traffic-generator-stack.js
+++ b/cdk/agents/lib/pet-clinic-agents-traffic-generator-stack.js
@@ -3,6 +3,7 @@ const lambda = require('aws-cdk-lib/aws-lambda');
 const events = require('aws-cdk-lib/aws-events');
 const targets = require('aws-cdk-lib/aws-events-targets');
 const iam = require('aws-cdk-lib/aws-iam');
+const crypto = require('crypto');
 
 /**
  * Lambda traffic generator for AI agents to simulate user interactions.
@@ -20,7 +21,8 @@ class PetClinicAgentsTrafficGeneratorStack extends Stack {
       environment: {
         PRIMARY_AGENT_ARN: props?.primaryAgentArn || '',
         NUTRITION_AGENT_ARN: props?.nutritionAgentArn || '',
-        REQUESTS_PER_INVOKE: '20'
+        REQUESTS_PER_INVOKE: '20',
+        SESSION_ID: `pet-clinic-traffic-generator-${crypto.randomUUID()}`
       }
     });
 

--- a/pet_clinic_ai_agents/nutrition_agent/requirements.txt
+++ b/pet_clinic_ai_agents/nutrition_agent/requirements.txt
@@ -4,4 +4,4 @@ uv
 boto3
 bedrock-agentcore
 bedrock-agentcore-starter-toolkit
-aws-opentelemetry-distro>=0.11.0
+aws-opentelemetry-distro>=0.12.1

--- a/pet_clinic_ai_agents/primary_agent/requirements.txt
+++ b/pet_clinic_ai_agents/primary_agent/requirements.txt
@@ -4,4 +4,4 @@ uv
 boto3
 bedrock-agentcore
 bedrock-agentcore-starter-toolkit
-aws-opentelemetry-distro>=0.11.0
+aws-opentelemetry-distro>=0.12.1


### PR DESCRIPTION
*Description of changes:*
- The latest ADOT release includes a fix to suppress noisy POST /invocations spans. Updating the requirements.txt to use this version helps reduce the volume of these spans. ref: https://github.com/aws-observability/aws-otel-python-instrumentation/pull/464

- Modify the traffic generator to generate and include a SESSION_ID in the InvokeAgent call, following the best practices outlined by the Bedrock AgentCore runtime. ref: https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/runtime-invoke-agent.html#runtime-invoke-session-management

- Specify the region when creating the boto3 Bedrock AgentCore client, as it is a required parameter.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

