### PR TITLE
[SECURITY] Mitigation for CVE-2025-41235; Pin spring-cloud-starter-gateway version and disable forwarded headers

### DIFF
--- a/spring-petclinic-api-gateway/pom.xml
+++ b/spring-petclinic-api-gateway/pom.xml
@@ -63,6 +63,7 @@
     <dependency>
       <groupId>org.springframework.cloud</groupId>
       <artifactId>spring-cloud-starter-gateway</artifactId>
+      <version>3.1.9</version>
     </dependency>
     <dependency>
       <groupId>org.springframework</groupId>

--- a/spring-petclinic-api-gateway/src/main/resources/application.yml
+++ b/spring-petclinic-api-gateway/src/main/resources/application.yml
@@ -3,6 +3,12 @@ spring:
     name: api-gateway
   config:
     import: optional:configserver:${CONFIG_SERVER_URL:http://localhost:8888/}
+  cloud:
+    gateway:
+      forwarded:
+        enabled: false
+      x-forwarded:
+        enabled: false
 
 eureka:
   instance:


### PR DESCRIPTION
- Pin spring-cloud-starter-gateway to version 3.1.9 in api-gateway pom.xml
- Disable forwarded and x-forwarded headers in gateway configuration to prevent header manipulation