### PR TITLE
Upgrade bedrock model to Sonnet 4.5 and fix issues with bean wiring

### DIFF
--- a/pet_clinic_ai_agents/nutrition_agent/nutrition_agent.py
+++ b/pet_clinic_ai_agents/nutrition_agent/nutrition_agent.py
@@ -7,7 +7,7 @@ import uuid
 from strands.models import BedrockModel
 from bedrock_agentcore.runtime import BedrockAgentCoreApp
 
-BEDROCK_MODEL_ID = "us.anthropic.claude-3-5-haiku-20241022-v1:0"
+BEDROCK_MODEL_ID = "anthropic.claude-sonnet-4-5-20250929-v1:0"
 NUTRITION_SERVICE_URL = os.environ.get('NUTRITION_SERVICE_URL')
 
 agent = None

--- a/pet_clinic_ai_agents/primary_agent/pet_clinic_agent.py
+++ b/pet_clinic_ai_agents/primary_agent/pet_clinic_agent.py
@@ -8,7 +8,7 @@ from strands.models import BedrockModel
 from bedrock_agentcore.runtime import BedrockAgentCoreApp
 from botocore.exceptions import ClientError
 
-BEDROCK_MODEL_ID = "us.anthropic.claude-3-5-haiku-20241022-v1:0"
+BEDROCK_MODEL_ID = "anthropic.claude-sonnet-4-5-20250929-v1:0"
 
 @tool
 def get_clinic_hours():

--- a/spring-petclinic-api-gateway/src/main/java/org/springframework/samples/petclinic/api/boundary/web/AgentController.java
+++ b/spring-petclinic-api-gateway/src/main/java/org/springframework/samples/petclinic/api/boundary/web/AgentController.java
@@ -30,12 +30,12 @@ public class AgentController {
 
     private String nutritionAgentArn = System.getenv("NUTRITION_AGENT_ARN");
 
-    private String awsRegion = "us-east-1";
+    private String awsRegion = System.getenv().getOrDefault("AWS_REGION", "us-east-1");
 
     private final BedrockAgentCoreClient bedrockClient;
     private final String sessionId;
 
-    public AgentController(String region) {
+    public AgentController() {
         this.bedrockClient = BedrockAgentCoreClient.builder()
                 .region(Region.of(awsRegion))
                 .credentialsProvider(software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider.builder().build())
@@ -68,7 +68,7 @@ public class AgentController {
         String payload = String.format("{\"prompt\": \"%s\"}", escapeJson(prompt));
 
         InvokeAgentRuntimeRequest invokeRequest = InvokeAgentRuntimeRequest.builder()
-                .agentRuntimeArn("arn:aws:bedrock-agentcore:us-east-1:140023401067:runtime/pet_clinic_agent-1237f9CoGU")
+                .agentRuntimeArn(primaryAgentArn)
                 .qualifier("DEFAULT")
                 .runtimeSessionId(sessionId)
                 .contentType("application/json")


### PR DESCRIPTION
*Description of changes:*

- Fix issue with AgentController bean autowiring

- Fix AgentController to use `PRIMARY_AGENT_ARN` and `AWS_REGION` environment variables instead of hardcoded values 

- Upgrade Bedrock model from Claude 3.5 Haiku to Claude Sonnet 4.5 for improved AI agent performance.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

