### PR TITLE
fix: replace EOL amazon.titan-text-express-v1 with claude-sonnet-4-5

### DIFF
--- a/spring-petclinic-customers-service/src/main/java/org/springframework/samples/petclinic/customers/aws/BedrockRuntimeV1Service.java
+++ b/spring-petclinic-customers-service/src/main/java/org/springframework/samples/petclinic/customers/aws/BedrockRuntimeV1Service.java
@@ -45,20 +45,20 @@ public class BedrockRuntimeV1Service {
 
     public String invokeTitanModel(String petType) {
         try {
-            String modelId = "amazon.titan-text-express-v1";
+            String modelId = "us.anthropic.claude-sonnet-4-5-20250929-v1:0";
             String inputText = String.format("What's the common disease for a %s?", petType);
             float temperature = 0.8f;
-            float topP = 0.9f;
             int maxTokenCount = 1000;
 
-            JSONObject textGenerationConfig = new JSONObject();
-            textGenerationConfig.put("temperature", temperature);
-            textGenerationConfig.put("topP", topP);
-            textGenerationConfig.put("maxTokenCount", maxTokenCount);
+            JSONObject message = new JSONObject();
+            message.put("role", "user");
+            message.put("content", inputText);
 
             JSONObject nativeRequestObject = new JSONObject();
-            nativeRequestObject.put("inputText", inputText);
-            nativeRequestObject.put("textGenerationConfig", textGenerationConfig);
+            nativeRequestObject.put("anthropic_version", "bedrock-2023-05-31");
+            nativeRequestObject.put("max_tokens", maxTokenCount);
+            nativeRequestObject.put("temperature", temperature);
+            nativeRequestObject.put("messages", new JSONArray().put(message));
 
             String nativeRequest = nativeRequestObject.toString();
             ByteBuffer buffer = StandardCharsets.UTF_8.encode(nativeRequest);
@@ -73,16 +73,14 @@ public class BedrockRuntimeV1Service {
             resultBodyBuffer.get(bytes);
             String result_body = new String(bytes, StandardCharsets.UTF_8);
 
-            String generatedText = "";
             JSONObject jsonObject = new JSONObject(result_body);
-            int inputTextTokenCount = jsonObject.getInt("inputTextTokenCount");
-            JSONArray resultsArray = jsonObject.getJSONArray("results");
-            JSONObject firstResult = resultsArray.getJSONObject(0);
-            int outputTokenCount = firstResult.getInt("tokenCount");
-            generatedText = firstResult.getString("outputText");
-            String completionReason = firstResult.getString("completionReason");
+            JSONObject usage = jsonObject.getJSONObject("usage");
+            int inputTextTokenCount = usage.getInt("input_tokens");
+            int outputTokenCount = usage.getInt("output_tokens");
+            String generatedText = jsonObject.getJSONArray("content").getJSONObject(0).getString("text");
+            String completionReason = jsonObject.getString("stop_reason");
             log.info(
-                    "Invoke Titan Model Result: " +
+                    "Invoke Model Result: " +
                             "{ " +
                             "\"modelId\": \"" + modelId + "\", " +
                             "\"prompt_token_count\": " + inputTextTokenCount + ", " +
@@ -90,14 +88,12 @@ public class BedrockRuntimeV1Service {
                             "\"prompt\": \"" + inputText + "\", " +
                             "\"generated_text\": \"" + generatedText.replace("\n", " ") + "\", " +
                             "\"stop_reason\": \"" + completionReason + "\", " +
-                            "\"temperature\": " + temperature + ", " +
-                            "\"top_p\": " + topP + ", " +
-                            "\"max_gen_len\": " + maxTokenCount +
+                            "\"temperature\": " + temperature +
                             " }"
             );
-            return "Invoke titan Model Result: " + result_body;
+            return "Invoke Model Result: " + result_body;
         } catch (Exception e) {
-            log.error("Invoke titan Model Result: Error: %s", e.getMessage());
+            log.error("Invoke Model Result: Error: %s", e.getMessage());
             throw e;
         }
     }

--- a/spring-petclinic-customers-service/src/main/java/org/springframework/samples/petclinic/customers/aws/BedrockRuntimeV1Service.java
+++ b/spring-petclinic-customers-service/src/main/java/org/springframework/samples/petclinic/customers/aws/BedrockRuntimeV1Service.java
@@ -43,7 +43,7 @@ public class BedrockRuntimeV1Service {
 
     }
 
-    public String invokeTitanModel(String petType) {
+    public String invokeModel(String petType) {
         try {
             String modelId = "us.anthropic.claude-sonnet-4-5-20250929-v1:0";
             String inputText = String.format("What's the common disease for a %s?", petType);

--- a/spring-petclinic-customers-service/src/main/java/org/springframework/samples/petclinic/customers/web/PetResource.java
+++ b/spring-petclinic-customers-service/src/main/java/org/springframework/samples/petclinic/customers/web/PetResource.java
@@ -105,7 +105,7 @@ class PetResource {
         bedrockV1Service.getGuardrail();
         log.info("bedrockV1Service FINISH Getting guardrail");
         log.info("DEBUG: CALLING BEDROCK petId = " + petId);
-        log.info("DEBUG: bedrockRuntimeV1Service Invoking Titan model");
+        log.info("DEBUG: bedrockRuntimeV1Service Invoking model");
         String petType = "pets";
         try {
             Pet pet = findPetById(petId);
@@ -116,8 +116,8 @@ class PetResource {
             log.error("Failed to find pet: '{}' ", petId);
         }
 
-        bedrockRuntimeV1Service.invokeTitanModel(petType);
-        log.info("bedrockRuntimeV1Service FINISH Invoking Titan model");
+        bedrockRuntimeV1Service.invokeModel(petType);
+        log.info("bedrockRuntimeV1Service FINISH Invoking model");
         log.info("bedrockAgentV2Service Getting knowledge base");
         bedrockAgentV2Service.bedrockAgentGetKnowledgeBaseV2();
         log.info("bedrockAgentV2Service FINISH Getting knowledge base");


### PR DESCRIPTION
## Summary
Replaces the deprecated `amazon.titan-text-express-v1` model (AWS EOL) in
`BedrockRuntimeV1Service.java` with `us.anthropic.claude-sonnet-4-5-20250929-v1:0`.

## Changes
- Updated model ID to `us.anthropic.claude-sonnet-4-5-20250929-v1:0`
- Updated request format from Titan API to Claude Messages API
- Updated response parsing from Titan format to Claude format
- Removed `top_p` (not supported alongside `temperature` in Claude)

## Motivation
`amazon.titan-text-express-v1` has reached end-of-life and all invocations are
failing with `ResourceNotFoundException`. This aligns the customers-service with
the rest of the demo app which already uses Claude Sonnet 4.5.

## Testing

1. Build verification
Installed Java 17 (required — project incompatible with Java 21 due to Lombok) and ran:
`./mvnw clean package -DskipTests`

Result: BUILD SUCCESS

2. Local runtime test
Started the Spring Boot JAR locally with config/eureka disabled:
```
java -jar spring-petclinic-customers-service-2.6.7.jar \
  --spring.cloud.config.enabled=false \
  --eureka.client.enabled=false \
  --server.port=8081 \
  --logging.level.org.springframework.samples.petclinic.customers.aws=INFO
```

Called the diagnose endpoint: `GET /diagnose/owners/1/pets/1`

3. Application log verification
Log from BedrockRuntimeV1Service confirmed the new model was called and returned a real response:
```
Invoke Model Result: {
  "modelId": "us.anthropic.claude-sonnet-4-5-20250929-v1:0",
  "prompt_token_count": 16,
  "generation_token_count": 282,
  "stop_reason": "end_turn"
}
```

No "Titan" anywhere in the logs.

4. AWS CloudTrail verification
CloudTrail in my dev account confirmed two successful calls to the new model:

| Time | Model | Input tokens | Output tokens | Error |
|------|-------|-------------|---------------|-------|
| 16:34:24 | us.anthropic.claude-sonnet-4-5-20250929-v1:0 | 16 | 282 | None |
| 16:36:25 | us.anthropic.claude-sonnet-4-5-20250929-v1:0 | 16 | 267 | None |


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

