### PR TITLE
fix: Pin IAM module version to v5.46.0

### DIFF
--- a/terraform/eks/main.tf
+++ b/terraform/eks/main.tf
@@ -175,6 +175,7 @@ module "eks" {
 module "demo_service_account" {
   #checkov:skip=CKV_TF_1:sub-module hash key ignored
   source = "terraform-aws-modules/iam/aws//modules/iam-assumable-role-with-oidc"
+  version = "5.46.0"
 
   create_role                   = true
   role_name                     = "DemoServiceRole-${var.cluster_name}"

--- a/terraform/eks/observability.tf
+++ b/terraform/eks/observability.tf
@@ -10,7 +10,8 @@ resource "aws_eks_addon" "cloudwatch_observability" {
 module "irsa_cloudwatch_observability" {
   #checkov:skip=CKV_TF_1:sub-module hash key ignored
   source = "terraform-aws-modules/iam/aws//modules/iam-assumable-role-with-oidc"
-
+  version = "5.46.0"
+  
   create_role                   = true
   role_name                     = "AmazonCloudWatchObservabilityAddonRole-${var.cluster_name}"
   provider_url                  = replace(module.eks.oidc_provider, "https://", "")


### PR DESCRIPTION
### Problem
- IAM module (`iam-assumable-role-with-oidc`) has no pinned version
- Without a version constraint, `terraform init` pulls the latest release (v6.0)
- v6.0 requires AWS provider >= 6.28.0, which conflicts with this project's 
  AWS provider constraint (~> 5.44.0)
- This causes `terraform init` to fail with a provider version conflict

```
Downloading registry.terraform.io/terraform-aws-modules/iam/aws 6.4.0 for demo_service_account...

demo_service_account in .terraform/modules/demo_service_account/modules/iam-assumable-role-with-oidc
Downloading registry.terraform.io/terraform-aws-modules/iam/aws 6.4.0 for irsa_cloudwatch_observability...
|
│ Error: Unreadable module subdirectory
│
│ The directory .terraform/modules/demo_service_account/modules/iam-assumable-role-with-oidc does not exist.
│ The target submodule modules/iam-assumable-role-with-oidc does not exist within the target module.
```

### Fix
- Pin `terraform-aws-modules/iam/aws` to `v5.46.0` (latest v5.x release)

### Files Changed
- `main.tf` — pinned `demo_service_account` module to v5.46.0
- `observability.tf` — pinned `irsa_cloudwatch_observability` module to v5.46.0

### Note
- Migration to `iam-role` (v6.0) requires AWS provider >= 6.28.0
- Current project uses AWS provider ~> 5.44.0
- v6.0 migration should be done in a separate PR alongside AWS provider upgrade

### Reference
- https://github.com/terraform-aws-modules/terraform-aws-iam/blob/master/docs/UPGRADE-6.0.md