### PR TITLE
Pin GitHub Action references to commit SHAs

### DIFF
--- a/.github/workflows/awsapm.yml
+++ b/.github/workflows/awsapm.yml
@@ -64,7 +64,7 @@ jobs:
       - name: Run Claude Investigation - Attempt 1
         id: claude
         continue-on-error: true
-        uses: anthropics/claude-code-base-action@e8132bc5e637a42c27763fc757faa37e1ee43b34 #beta
+        uses: anthropics/claude-code-base-action@e8132bc5e637a42c27763fc757faa37e1ee43b34 #v0.0.63
         with:
           use_bedrock: "true" 
           # Set to any Bedrock Model ID 
@@ -77,7 +77,7 @@ jobs:
       - name: Run Claude Investigation - Attempt 2
         id: claude-retry
         if: steps.claude.outcome == 'failure'
-        uses: anthropics/claude-code-base-action@e8132bc5e637a42c27763fc757faa37e1ee43b34 #beta
+        uses: anthropics/claude-code-base-action@e8132bc5e637a42c27763fc757faa37e1ee43b34 #v0.0.63
         with:
           use_bedrock: "true"
           model: "us.anthropic.claude-sonnet-4-5-20250929-v1:0"

--- a/.github/workflows/awsapm.yml
+++ b/.github/workflows/awsapm.yml
@@ -42,10 +42,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 #v4.3.1
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a #v4.3.1
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
           aws-region: ${{ vars.AWS_REGION || 'us-east-1' }}
@@ -55,7 +55,7 @@ jobs:
       # - https://github.com/anthropics/claude-code-action/issues/693
       - name: Prepare Investigation Context
         id: prepare
-        uses: aws-actions/application-observability-for-aws@v1
+        uses: aws-actions/application-observability-for-aws@95bb59e4538ba9ef746805d8a2bbbe531ba2a728 #v1.1.1
         with:
           bot_name: "@awsapm"
           cli_tool: "claude_code"
@@ -64,7 +64,7 @@ jobs:
       - name: Run Claude Investigation - Attempt 1
         id: claude
         continue-on-error: true
-        uses: anthropics/claude-code-base-action@beta
+        uses: anthropics/claude-code-base-action@e8132bc5e637a42c27763fc757faa37e1ee43b34 #beta
         with:
           use_bedrock: "true" 
           # Set to any Bedrock Model ID 
@@ -77,7 +77,7 @@ jobs:
       - name: Run Claude Investigation - Attempt 2
         id: claude-retry
         if: steps.claude.outcome == 'failure'
-        uses: anthropics/claude-code-base-action@beta
+        uses: anthropics/claude-code-base-action@e8132bc5e637a42c27763fc757faa37e1ee43b34 #beta
         with:
           use_bedrock: "true"
           model: "us.anthropic.claude-sonnet-4-5-20250929-v1:0"
@@ -88,7 +88,7 @@ jobs:
       # Step 3: Post results back to GitHub issue/PR
       - name: Post Investigation Results
         if: always()
-        uses: aws-actions/application-observability-for-aws@v1
+        uses: aws-actions/application-observability-for-aws@95bb59e4538ba9ef746805d8a2bbbe531ba2a728 #v1.1.1
         with:
           cli_tool: "claude_code"
           comment_id: ${{ steps.prepare.outputs.awsapm_comment_id }}

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -1,0 +1,36 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT
+
+name: PR Build
+on:
+  pull_request:
+  
+permissions:
+  contents: read
+
+# TODO: Add build/test steps
+jobs:
+  static-code-checks:
+    runs-on: ubuntu-latest
+    steps:
+
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 #5.0.0
+        with:
+          fetch-depth: 0
+      - name: Check for versioned GitHub actions
+        if: always()
+        run: |
+          # Get changed GitHub workflow/action files
+          CHANGED_FILES=$(git diff --name-only origin/${{ github.base_ref }}..HEAD | grep -E "^\.github/(workflows|actions)/.*\.ya?ml$" || true)
+          
+          if [ -n "$CHANGED_FILES" ]; then
+            # Check for any versioned actions, excluding comments and this validation script
+            VIOLATIONS=$(grep -Hn "uses:.*@v" $CHANGED_FILES | grep -v "grep.*uses:.*@v" | grep -v "#.*@v" || true)
+            if [ -n "$VIOLATIONS" ]; then
+              echo "Found versioned GitHub actions. Use commit SHAs instead:"
+              echo "$VIOLATIONS"
+              exit 1
+            fi
+          fi
+          
+          echo "No versioned actions found in changed files"

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -20,3 +20,28 @@ jobs:
     with:
       aws-region: 'us-east-1'
       test-cluster-name: 'e2e-enablement-script-test'
+
+  static-code-checks:
+    runs-on: ubuntu-latest
+    steps:
+
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 #5.0.0
+        with:
+          fetch-depth: 0
+      - name: Check for versioned GitHub actions
+        if: always()
+        run: |
+          # Get changed GitHub workflow/action files
+          CHANGED_FILES=$(git diff --name-only origin/${{ github.base_ref }}..HEAD | grep -E "^\.github/(workflows|actions)/.*\.ya?ml$" || true)
+          
+          if [ -n "$CHANGED_FILES" ]; then
+            # Check for any versioned actions, excluding comments and this validation script
+            VIOLATIONS=$(grep -Hn "uses:.*@v" $CHANGED_FILES | grep -v "grep.*uses:.*@v" | grep -v "#.*@v" || true)
+            if [ -n "$VIOLATIONS" ]; then
+              echo "Found versioned GitHub actions. Use commit SHAs instead:"
+              echo "$VIOLATIONS"
+              exit 1
+            fi
+          fi
+          
+          echo "No versioned actions found in changed files"

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -20,28 +20,3 @@ jobs:
     with:
       aws-region: 'us-east-1'
       test-cluster-name: 'e2e-enablement-script-test'
-
-  static-code-checks:
-    runs-on: ubuntu-latest
-    steps:
-
-      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 #5.0.0
-        with:
-          fetch-depth: 0
-      - name: Check for versioned GitHub actions
-        if: always()
-        run: |
-          # Get changed GitHub workflow/action files
-          CHANGED_FILES=$(git diff --name-only origin/${{ github.base_ref }}..HEAD | grep -E "^\.github/(workflows|actions)/.*\.ya?ml$" || true)
-          
-          if [ -n "$CHANGED_FILES" ]; then
-            # Check for any versioned actions, excluding comments and this validation script
-            VIOLATIONS=$(grep -Hn "uses:.*@v" $CHANGED_FILES | grep -v "grep.*uses:.*@v" | grep -v "#.*@v" || true)
-            if [ -n "$VIOLATIONS" ]; then
-              echo "Found versioned GitHub actions. Use commit SHAs instead:"
-              echo "$VIOLATIONS"
-              exit 1
-            fi
-          fi
-          
-          echo "No versioned actions found in changed files"


### PR DESCRIPTION
## Summary

Pin all GitHub Action references to full commit SHAs instead of mutable version tags to prevent supply chain attacks. This is a security best practice recommended by [GitHub's security hardening guide](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions).

Mutable version tags (e.g. `@v2`) can be moved to point to different commits, meaning a compromised upstream action could execute malicious code in our workflows. Pinning to commit SHAs ensures we always run the exact code we've reviewed.

## Changes

| Old Reference | New Reference | Hash | Version |
|--------------|---------------|------|---------|
| actions/checkout@v4 | actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 | 34e114876b0b11c390a56381ad16ebd13914f8d5 | [v4.3.1](https://github.com/actions/checkout/releases/tag/v4.3.1) |
| anthropics/claude-code-base-action@beta | anthropics/claude-code-base-action@e8132bc5e637a42c27763fc757faa37e1ee43b34 | e8132bc5e637a42c27763fc757faa37e1ee43b34 | [v0.063](http://github.com/anthropics/claude-code-base-action/releases/tag/v0.0.63) |
| aws-actions/application-observability-for-aws@v1 | aws-actions/application-observability-for-aws@95bb59e4538ba9ef746805d8a2bbbe531ba2a728 | 95bb59e4538ba9ef746805d8a2bbbe531ba2a728 | [v1.1.1](https://github.com/aws-actions/application-observability-for-aws/releases/tag/v1.1.1) |
| aws-actions/configure-aws-credentials@v4 | aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a | 7474bc4690e29a8392af63c5b98e7449536d5c3a | [v4.3.1](https://github.com/aws-actions/configure-aws-credentials/releases/tag/v4.3.1) |

## Static Code Check

Added a `static-code-checks` job to `release-build.yml` that will fail PRs introducing mutable GitHub Action version references.
