### PR TITLE
pin CW addon to v4.10.3-eksbuild.1

### DIFF
--- a/scripts/eks/appsignals/enable-app-signals.sh
+++ b/scripts/eks/appsignals/enable-app-signals.sh
@@ -59,6 +59,7 @@ if [[ "${result}" == *"No addon: "* ]];  then
     aws eks create-addon \
         --cluster-name ${CLUSTER_NAME} \
         --addon-name amazon-cloudwatch-observability \
+        --addon-version v4.10.3-eksbuild.1 \
         --region ${REGION}
     # wait until the amazon-cloudwatch-observability add-on is active    
     # Fetch the initial status


### PR DESCRIPTION
## Summary
- Pin `amazon-cloudwatch-observability` addon to `v4.10.3-eksbuild.1` in `enable-app-signals.sh`
- v5.3.0 removed cluster-wide configmap `get` from the CW agent ClusterRole (aws-observability/helm-charts#287), breaking the EKS resource detector's `aws-auth` configmap lookup
- This caused all EKS E2E tests across Python and Java to fail since Apr 1 with `origin=AWS::EC2::Instance` instead of `AWS::EKS::Container`

## Test plan
- [ ] Re-run Python EKS E2E tests and confirm trace validation passes