### PR TITLE
Revert "pin CW addon to v4.10.3-eksbuild.1 (#334)"

### DIFF
--- a/scripts/eks/appsignals/enable-app-signals.sh
+++ b/scripts/eks/appsignals/enable-app-signals.sh
@@ -59,7 +59,6 @@ if [[ "${result}" == *"No addon: "* ]];  then
     aws eks create-addon \
         --cluster-name ${CLUSTER_NAME} \
         --addon-name amazon-cloudwatch-observability \
-        --addon-version v4.10.3-eksbuild.1 \
         --region ${REGION}
     # wait until the amazon-cloudwatch-observability add-on is active    
     # Fetch the initial status


### PR DESCRIPTION
This reverts commit 8b3584d5011da55259ea71c19d08f2ff50d825c1.

*Description of changes:*

Revert https://github.com/aws-observability/application-signals-demo/pull/334 since CloudWatch Agent releases EKS add-on v5.3.1, has addressed EKS resource detector issue.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

