### PR TITLE
Fix ECS demo on Apple Silicon Macs and stabilise service startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,9 +17,10 @@ This code for sample application is intended for demonstration purposes only. It
 * Node.js >= v18.0.0 is installed.
 
 ## Option 2: Local Build Environment
-* A Linux machine with x86-64 (AMD64) architecture is required for building Docker images for the sample application.
-* Docker is installed and running on the machine.
+* Linux x86-64 or macOS (Intel or Apple Silicon). macOS users: see the [ECS Demo macOS notes](#macos-notes) — the default Maven `buildDocker` profile does not work on macOS.
+* Docker is installed and running (Docker Desktop, Colima, or Rancher Desktop).
 * AWS CLI 2.x is installed. For more information about installing the AWS CLI, see [Install or update the latest version of the AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html).
+* Java 17 (Amazon Corretto recommended).
 * Golang is installed.
 
 ## Additional Prerequisites for Deployment
@@ -149,24 +150,41 @@ The following instructions set up an kubernetes cluster on 2 EC2 instances (one 
 # ECS Demo
 The following instructions set up an ECS cluster with all services running in Fargate. You can run these steps in your personal AWS account to follow along (Not recommended for production usage).
 
-1. Build container images and push them to private ECR repo. Replace `region-name` with the region you choose.
+## macOS notes
+
+The default `./mvnw -P buildDocker` command uses the archived Spotify `docker-maven-plugin`, which does not run on Apple Silicon. On macOS, use [build-docker.sh](build-docker.sh) instead — it drives `docker build` directly against [docker/Dockerfile](docker/Dockerfile). [otel-collector/ocb.sh](otel-collector/ocb.sh) also builds natively on the host (macOS or Linux) and cross-compiles the collector for `linux/amd64`.
+
+Install: `brew install jq wget node go awscli && npm i -g aws-cdk`. Start a Docker daemon (Docker Desktop, Colima, or Rancher Desktop) — for Colima, also `export DOCKER_HOST=unix://$HOME/.colima/default/docker.sock`.
+
+## Deploy
+
+1. Build container images and push them to private ECR. Replace `region-name` with the region you choose.
    ```shell
-   export ACCOUNT=`aws sts get-caller-identity | jq .Account -r`
+   export ACCOUNT=$(aws sts get-caller-identity --query Account --output text)
    export REGION=region-name
    ```
-   ``` shell
+   On **Linux x86-64**:
+   ```shell
    ./mvnw clean install -P buildDocker && ./push-ecr.sh
    ```
-
-2. Set up a ECS cluster and deploy sample app. Replace `region-name` with the region you choose.
-
-   ``` shell
-   cd scripts/ecs/appsignals && ./setup-ecs-demo.sh --region=region-name
-   ``` 
-
-3. Clean up after you are done with the sample app. Replace `region-name` with the same value that you use in previous step.
+   On **macOS**:
+   ```shell
+   ./mvnw clean install -DskipTests
+   ./build-docker.sh
+   ./push-ecr.sh
    ```
-   cd scripts/ecs/appsignals/ && ./setup-ecs-demo.sh --operation=delete --region=region-name
+   `push-ecr.sh` creates the ECR repos (existing-repo errors are safe to ignore — the script continues) and builds/pushes the Python, Node, .NET, traffic-generator, and otel-collector images inline.
+
+   > **Note:** The ECS CDK stack does not reference `dotnet-petclinic-payment` — that image is only used by the EKS demo. If the .NET build hangs on Apple Silicon (QEMU emulation of `dotnet restore` is very slow), you can safely skip it: `Ctrl-C` `push-ecr.sh` after the Python/Node/traffic-generator/otel-collector images push, and the empty `dotnet-petclinic-payment` ECR repo will not block the ECS deploy.
+
+2. Deploy the ECS cluster and sample app:
+   ```shell
+   cd scripts/ecs/appsignals && ./setup-ecs-demo.sh --region=region-name
+   ```
+
+3. Clean up when done:
+   ```shell
+   cd scripts/ecs/appsignals && ./setup-ecs-demo.sh --operation=delete --region=region-name
    ```
 
 # Bedrock AgentCore Runtime Demo

--- a/build-docker.sh
+++ b/build-docker.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+VERSION=$(./mvnw help:evaluate -Dexpression=project.version -q -DforceStdout)
+
+SERVICES=(
+  spring-petclinic-admin-server
+  spring-petclinic-api-gateway
+  spring-petclinic-config-server
+  spring-petclinic-customers-service
+  spring-petclinic-discovery-server
+  spring-petclinic-vets-service
+  spring-petclinic-visits-service
+)
+
+for svc in "${SERVICES[@]}"; do
+  echo ">>> Building $svc"
+  docker build \
+    --platform linux/amd64 \
+    --build-arg ARTIFACT_NAME="${svc}-${VERSION}" \
+    --build-arg EXPOSED_PORT=9090 \
+    --build-arg DOCKERIZE_VERSION=v0.6.1 \
+    -f docker/Dockerfile \
+    -t "springcommunity/${svc}:latest" \
+    "$svc/target"
+done

--- a/cdk/ecs/lib/stacks/ecsStack.ts
+++ b/cdk/ecs/lib/stacks/ecsStack.ts
@@ -6,6 +6,7 @@ import { Secret as SmSecret } from 'aws-cdk-lib/aws-secretsmanager';
 import {
     Cluster,
     Compatibility,
+    ContainerDependencyCondition,
     ContainerImage,
     FargateService,
     HealthCheck,
@@ -217,6 +218,10 @@ export class EcsClusterStack extends Stack {
             },
             assignPublicIp: false,
             desiredCount: 1,
+            // Spring Boot + OTel javaagent takes ~150s to reach a responsive state on Fargate.
+            // Without this grace period the ALB starts health-checking too early, marks the
+            // task unhealthy, and ECS kills it in a loop.
+            healthCheckGracePeriod: Duration.seconds(360),
         });
 
         // Add Application Load Balancer target group
@@ -296,7 +301,8 @@ export class EcsClusterStack extends Stack {
             interval: Duration.seconds(60),
             timeout: Duration.seconds(10),
             retries: 5,
-            startPeriod: Duration.seconds(3),
+            // 3s was too short — Django needs ~30s to run migrations and start.
+            startPeriod: Duration.seconds(60),
         };
 
         const insuranceConfig: ServiceTaskDefinitionConfig = {
@@ -554,6 +560,14 @@ export class EcsClusterStack extends Stack {
             readOnly: false,
         });
 
+        // Main container must wait for init container to finish copying the ADOT
+        // javaagent JAR into the shared volume, otherwise the JVM fails to start
+        // with "Error opening zip file or JAR manifest missing".
+        mainContainer.addContainerDependencies({
+            container: initContainer,
+            condition: ContainerDependencyCondition.COMPLETE,
+        });
+
         // Add CloudWatch agent container
         taskDefinition.addContainer(`${serviceName}-cwagent-container`, {
             image: ContainerImage.fromRegistry('public.ecr.aws/cloudwatch-agent/cloudwatch-agent:latest'),
@@ -671,6 +685,13 @@ export class EcsClusterStack extends Stack {
             sourceVolume: 'opentelemetry-auto-instrumentation-python',
             containerPath: '/otel-auto-instrumentation-python',
             readOnly: false,
+        });
+
+        // Main container must wait for init container to finish copying the ADOT
+        // Python auto-instrumentation files into the shared volume.
+        mainContainer.addContainerDependencies({
+            container: initContainer,
+            condition: ContainerDependencyCondition.COMPLETE,
         });
 
         // Add CloudWatch agent container

--- a/cdk/ecs/lib/stacks/loadbalancerStack.ts
+++ b/cdk/ecs/lib/stacks/loadbalancerStack.ts
@@ -40,13 +40,17 @@ export class LoadBalancerStack extends Stack {
             port: 8080,
             protocol: ApplicationProtocol.HTTP,
             targetType: TargetType.IP,
+            // '/' would work but it hits RumConfigFilter which buffers the whole
+            // index.html into memory before responding (~15s), causing flaky ALB
+            // health checks. '/actuator/health' bypasses the filter and returns
+            // fast, so we can also tighten the intervals safely.
             healthCheck: {
-                path: '/',
+                path: '/actuator/health',
                 protocol: Protocol.HTTP,
-                healthyThresholdCount: 5,
-                unhealthyThresholdCount: 2,
-                interval: Duration.seconds(240),
-                timeout: Duration.seconds(60),
+                healthyThresholdCount: 2,
+                unhealthyThresholdCount: 3,
+                interval: Duration.seconds(30),
+                timeout: Duration.seconds(10),
             },
         });
 

--- a/otel-collector/.gitignore
+++ b/otel-collector/.gitignore
@@ -1,0 +1,3 @@
+ocb
+ocb_*
+otelcol-dev/

--- a/otel-collector/ocb.sh
+++ b/otel-collector/ocb.sh
@@ -2,26 +2,30 @@
 
 set -euo pipefail
 
-# Variables
 BUILDER_CONFIG="builder-config.yaml"
-OCB_BINARY="ocb"
-OCB_URL="https://github.com/open-telemetry/opentelemetry-collector-releases/releases/download/cmd%2Fbuilder%2Fv0.111.0/ocb_0.111.0_linux_amd64"
+OCB_VERSION="0.111.0"
 
-# Ensure the script is running in the correct directory
 if [[ ! -f "${BUILDER_CONFIG}" ]]; then
   echo "Error: ${BUILDER_CONFIG} not found in $(pwd)"
   exit 1
 fi
 
-# Download the OCB binary if not present
-if [[ ! -f "${OCB_BINARY}" ]]; then
-  echo "Downloading OpenTelemetry Collector Builder..."
-  wget "${OCB_URL}" -O "${OCB_BINARY}"
+HOST_OS="$(uname -s | tr '[:upper:]' '[:lower:]')"
+HOST_ARCH_RAW="$(uname -m)"
+case "${HOST_ARCH_RAW}" in
+  x86_64|amd64) HOST_ARCH="amd64" ;;
+  arm64|aarch64) HOST_ARCH="arm64" ;;
+  *) echo "Unsupported host arch: ${HOST_ARCH_RAW}"; exit 1 ;;
+esac
+
+OCB_BINARY="ocb_${HOST_OS}_${HOST_ARCH}"
+OCB_URL="https://github.com/open-telemetry/opentelemetry-collector-releases/releases/download/cmd%2Fbuilder%2Fv${OCB_VERSION}/ocb_${OCB_VERSION}_${HOST_OS}_${HOST_ARCH}"
+
+if [[ ! -x "${OCB_BINARY}" ]]; then
+  echo "Downloading OpenTelemetry Collector Builder (${HOST_OS}/${HOST_ARCH})..."
+  curl -fSL "${OCB_URL}" -o "${OCB_BINARY}"
   chmod +x "${OCB_BINARY}"
 fi
 
-# Build the collector
-echo "Building OpenTelemetry Collector..."
-./"${OCB_BINARY}" --config "${BUILDER_CONFIG}"
-
-echo "Collector built successfully. Output is in the 'bin' directory."
+echo "Building OpenTelemetry Collector for linux/amd64..."
+GOOS=linux GOARCH=amd64 CGO_ENABLED=0 ./"${OCB_BINARY}" --config "${BUILDER_CONFIG}"

--- a/push-ecr.sh
+++ b/push-ecr.sh
@@ -33,28 +33,28 @@ docker push ${REPOSITORY_PREFIX}/springcommunity/spring-petclinic-admin-server:l
 
 
 aws ecr create-repository --repository-name python-petclinic-insurance-service --region ${REGION} --no-cli-pager || true
-docker build -t insurance-service ./pet_clinic_insurance_service --no-cache
+docker build --platform linux/amd64 -t insurance-service ./pet_clinic_insurance_service --no-cache
 docker tag insurance-service:latest ${REPOSITORY_PREFIX}/python-petclinic-insurance-service:latest
 docker push ${REPOSITORY_PREFIX}/python-petclinic-insurance-service:latest
 
 
 aws ecr create-repository --repository-name python-petclinic-billing-service --region ${REGION} --no-cli-pager || true
-docker build -t billing-service ./pet_clinic_billing_service --no-cache
+docker build --platform linux/amd64 -t billing-service ./pet_clinic_billing_service --no-cache
 docker tag billing-service:latest ${REPOSITORY_PREFIX}/python-petclinic-billing-service:latest
 docker push ${REPOSITORY_PREFIX}/python-petclinic-billing-service:latest
 
 aws ecr create-repository --repository-name nodejs-petclinic-nutrition-service --region ${REGION} --no-cli-pager || true
-docker build -t nutrition-service ./pet-nutrition-service --no-cache
+docker build --platform linux/amd64 -t nutrition-service ./pet-nutrition-service --no-cache
 docker tag nutrition-service:latest ${REPOSITORY_PREFIX}/nodejs-petclinic-nutrition-service:latest
 docker push ${REPOSITORY_PREFIX}/nodejs-petclinic-nutrition-service:latest
 
 aws ecr create-repository --repository-name traffic-generator --region ${REGION} --no-cli-pager || true
-docker build -t traffic-generator ./traffic-generator --no-cache
+docker build --platform linux/amd64 -t traffic-generator ./traffic-generator --no-cache
 docker tag traffic-generator:latest ${REPOSITORY_PREFIX}/traffic-generator:latest
 docker push ${REPOSITORY_PREFIX}/traffic-generator:latest
 
 aws ecr create-repository --repository-name dotnet-petclinic-payment --region ${REGION} --no-cli-pager || true
-docker build -t dotnet-petclinic-payment ./dotnet-petclinic-payment/PetClinic.PaymentService --no-cache
+docker build --platform linux/amd64 -t dotnet-petclinic-payment ./dotnet-petclinic-payment/PetClinic.PaymentService --no-cache
 docker tag dotnet-petclinic-payment:latest ${REPOSITORY_PREFIX}/dotnet-petclinic-payment:latest
 docker push ${REPOSITORY_PREFIX}/dotnet-petclinic-payment:latest
 

--- a/spring-petclinic-api-gateway/src/main/java/org/springframework/samples/petclinic/api/filter/RumConfigFilter.java
+++ b/spring-petclinic-api-gateway/src/main/java/org/springframework/samples/petclinic/api/filter/RumConfigFilter.java
@@ -65,8 +65,12 @@ public class RumConfigFilter implements WebFilter {
                             
                             // Create a new data buffer with modified content
                             byte[] modifiedBytes = content.getBytes(StandardCharsets.UTF_8);
+                            // Recompute Content-Length; the original header matched the
+                            // pre-replacement size, so leaving it triggers
+                            // ERR_CONTENT_LENGTH_MISMATCH in browsers.
+                            originalResponse.getHeaders().setContentLength(modifiedBytes.length);
                             DataBuffer modifiedBuffer = exchange.getResponse().bufferFactory().wrap(modifiedBytes);
-                            
+
                             return modifiedBuffer;
                         }).flatMap(Flux::just));
                     }


### PR DESCRIPTION
## Summary

The ECS demo did not run to completion on Apple Silicon and had latent races even on x86 Linux. This PR fixes the build path for macOS users and hardens the ECS stack so services reliably reach steady state.

## What was broken

- **Build:** `mvn -P buildDocker` uses the archived Spotify `docker-maven-plugin`, which bundles x86-only native libs and can't run on arm64. `otel-collector/ocb.sh` hardcoded a linux/amd64 binary and tried to `exec` it on the host.
- **Image arch:** `push-ecr.sh` did `docker build` without `--platform`, so on Apple Silicon it produced arm64 images that Fargate couldn't pull.
- **Init container race:** the CDK never declared a `dependsOn` between the ADOT init container (which copies `javaagent.jar` into a shared volume) and the main JVM container. Sometimes the JVM won the race and crashed with "Error opening zip file or JAR manifest missing".
- **ALB health checks:** the target group hit `/`, which triggers `RumConfigFilter` — that filter buffers the whole HTML into memory before responding (~15s), and the response failed in browsers with `ERR_CONTENT_LENGTH_MISMATCH` because `Content-Length` wasn't recomputed after mutation.
- **Grace period:** api-gateway takes ~150s to reach a responsive state on Fargate; the default 60s grace period got tasks killed mid-startup, which cascaded into CFN rollbacks.

## Changes

**New scripts:**
- `build-docker.sh` — plain `docker build` loop over the 7 Java services, replacing the Spotify plugin.
- `otel-collector/.gitignore` — ignore build artefacts.

**Fixes:**
- `push-ecr.sh` — `--platform linux/amd64` on inline builds.
- `otel-collector/ocb.sh` — detect host OS/arch, download the matching native `ocb` binary, cross-compile the collector for linux/amd64.
- `cdk/ecs/lib/stacks/ecsStack.ts` — main container `dependsOn: COMPLETE` on the ADOT init container (Java + Python). Insurance service `startPeriod` 3s → 60s (was a typo). Api-gateway service `healthCheckGracePeriod: 360s`.
- `cdk/ecs/lib/stacks/loadbalancerStack.ts` — health check `/` → `/actuator/health`, interval 240s → 30s, healthy threshold 5 → 2, timeout 60s → 10s.
- `spring-petclinic-api-gateway/.../RumConfigFilter.java` — recompute `Content-Length` after replacing template placeholders.

**Docs:**
- `README.md` — macOS build instructions and prerequisites. Note that `dotnet-petclinic-payment` is used only by the EKS demo (its build takes 40+ min on Apple Silicon under QEMU and can be safely skipped for ECS).

## Cross-platform safety

- The `--platform linux/amd64` flags are no-ops on x86_64 Linux.
- `ocb.sh` auto-detects the host arch, so Linux and macOS builders both work.
- The CDK health-check and grace-period changes are stricter about correctness — the original stack worked "when lucky" on fast networks and warm images. These changes make it deterministic.
- The `RumConfigFilter` Content-Length fix is a real bug that would affect any browser hitting `/`, not just Mac.

## Test plan

- [x] Local build on Apple Silicon: `./mvnw -DskipTests install && ./build-docker.sh && ./push-ecr.sh` succeeds
- [x] `cdk deploy EcsClusterStack --require-approval never` reaches CREATE_COMPLETE with all 10 services running
- [x] ALB URL serves the Pet Clinic UI with data (owners, vets, visits)
- [x] Application Signals populates the service map from real traffic
- [ ] Re-verify on x86_64 Linux (existing supported path) — no functional change expected